### PR TITLE
Switch from localstorage to IndexedDB for unbounded storage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,9 +29,6 @@ export default function App() {
       })
   }, [])
 
-  if (!ready) {
-    return null
-  }
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider defaultTheme="system" storageKey="pydantic-chat-ui-theme">
@@ -45,7 +42,7 @@ export default function App() {
                 'has-[.stick-to-bottom:empty]:overflow-visible has-[.stick-to-bottom:empty]:basis-[0px] transition-[flex-basis] duration-200',
               )}
             >
-              <Chat />
+              {ready && <Chat />}
             </div>
           </div>
         </SidebarProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,37 @@
+import { useEffect, useState } from 'react'
 import Chat from './Chat.tsx'
 import { AppSidebar } from './components/app-sidebar.tsx'
 import { ThemeProvider } from './components/theme-provider.tsx'
 import { SidebarProvider } from './components/ui/sidebar.tsx'
 import { Toaster } from './components/ui/sonner.tsx'
 import { cn } from './lib/utils.ts'
+import { migrateFromLocalStorage } from './lib/chat-db.ts'
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 const queryClient = new QueryClient()
 
 export default function App() {
+  const [ready, setReady] = useState(false)
+
+  useEffect(() => {
+    migrateFromLocalStorage()
+      .then((migrated) => {
+        if (migrated) {
+          window.dispatchEvent(new Event('conversations-changed'))
+        }
+      })
+      .catch((err: unknown) => {
+        console.error('Migration failed:', err)
+      })
+      .finally(() => {
+        setReady(true)
+      })
+  }, [])
+
+  if (!ready) {
+    return null
+  }
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider defaultTheme="system" storageKey="pydantic-chat-ui-theme">

--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -26,8 +26,8 @@ import { useThrottle } from '@uidotdev/usehooks'
 import { nanoid } from 'nanoid'
 import { useConversationIdFromUrl } from './hooks/useConversationIdFromUrl'
 import { Part } from './Part'
-import type { ConversationEntry } from './types'
 import { getToolIcon } from '@/lib/tool-icons'
+import { getMessages, saveMessages, saveConversation } from '@/lib/chat-db'
 
 interface ModelConfig {
   id: string
@@ -53,7 +53,7 @@ async function getModels() {
 
 const Chat = () => {
   const [input, setInput] = useState('')
-  const [model, setModel] = useState<string>('')
+  const [model, setModel] = useState('')
   const [enabledTools, setEnabledTools] = useState<string[]>([])
   const { messages, sendMessage, status, setMessages, regenerate, error } = useChat()
   const throttledMessages = useThrottle(messages, 500)
@@ -75,10 +75,15 @@ const Chat = () => {
     if (conversationId === '/') {
       setMessages([])
     } else {
-      const localStorageMessages = window.localStorage.getItem(conversationId)
-      if (localStorageMessages) {
-        setMessages(JSON.parse(localStorageMessages) as typeof messages)
-      }
+      getMessages(conversationId)
+        .then((storedMessages) => {
+          if (storedMessages) {
+            setMessages(storedMessages as typeof messages)
+          }
+        })
+        .catch((err: unknown) => {
+          console.error('Failed to load messages:', err)
+        })
     }
     textareaRef.current?.focus()
   }, [conversationId])
@@ -93,7 +98,7 @@ const Chat = () => {
         const newConversationId = `/${nanoid()}`
         setConversationId(newConversationId)
 
-        saveConversationEntryInLocalStorage(newConversationId, input)
+        saveConversationEntry(newConversationId, input)
 
         theCurrentUrl.pathname = newConversationId
         window.history.pushState({}, '', theCurrentUrl.toString())
@@ -112,8 +117,10 @@ const Chat = () => {
   }
 
   useEffect(() => {
-    if (conversationId && throttledMessages.length > 0) {
-      window.localStorage.setItem(conversationId, JSON.stringify(throttledMessages))
+    if (conversationId && conversationId !== '/' && throttledMessages.length > 0) {
+      saveMessages(conversationId, throttledMessages).catch((err: unknown) => {
+        console.error('Failed to save messages:', err)
+      })
     }
   }, [throttledMessages, conversationId])
 
@@ -261,19 +268,19 @@ export default Chat
 
 const MAX_FIRST_MESSAGE_LENGTH = 30
 
-function saveConversationEntryInLocalStorage(newConversationId: string, firstMessage: string) {
-  const currentConversations = window.localStorage.getItem('conversationIds') ?? '[]'
-  const conversationIds = JSON.parse(currentConversations) as ConversationEntry[]
+function saveConversationEntry(newConversationId: string, firstMessage: string) {
   const trimmedFirstMessage =
     firstMessage.length > MAX_FIRST_MESSAGE_LENGTH
       ? firstMessage.slice(0, MAX_FIRST_MESSAGE_LENGTH) + '...'
       : firstMessage
-  conversationIds.unshift({
+
+  saveConversation({
     id: newConversationId,
     firstMessage: trimmedFirstMessage,
     timestamp: Date.now(),
   })
-  window.localStorage.setItem('conversationIds', JSON.stringify(conversationIds))
-  // dispatch a custom event so that the sidebar can update
-  window.dispatchEvent(new Event('local-storage-change'))
+    .then(() => window.dispatchEvent(new Event('conversations-changed')))
+    .catch((err: unknown) => {
+      console.error('Failed to save conversation:', err)
+    })
 }

--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -19,7 +19,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { Switch } from '@/components/ui/switch'
 import { useChat } from '@ai-sdk/react'
 import { Settings2Icon } from 'lucide-react'
-import { useEffect, useLayoutEffect, useMemo, useRef, useState, type SyntheticEvent } from 'react'
+import { useEffect, useMemo, useRef, useState, type SyntheticEvent } from 'react'
 
 import { useQuery } from '@tanstack/react-query'
 import { useThrottle } from '@uidotdev/usehooks'
@@ -71,14 +71,14 @@ const Chat = () => {
     }
   }, [configQuery.data])
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (conversationId === '/') {
       setMessages([])
     } else {
       getMessages(conversationId)
         .then((storedMessages) => {
           if (storedMessages) {
-            setMessages(storedMessages as typeof messages)
+            setMessages(storedMessages)
           }
         })
         .catch((err: unknown) => {

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -28,34 +28,28 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { useConversationIdFromUrl } from '@/hooks/useConversationIdFromUrl'
 import { cn } from '@/lib/utils'
 import type { ConversationEntry } from '@/types'
+import { getConversations, deleteConversation as deleteConv } from '@/lib/chat-db'
 import { ModeToggle } from './mode-toggle'
 import logoSvg from '../assets/logo.svg'
 
 function useConversations(): ConversationEntry[] {
-  const [conversations, setConversations] = useState<ConversationEntry[]>(() => {
-    const stored = window.localStorage.getItem('conversationIds')
-    return stored ? (JSON.parse(stored) as ConversationEntry[]) : []
-  })
+  const [conversations, setConversations] = useState<ConversationEntry[]>([])
 
   useEffect(() => {
-    const handleStorageChange = (e: StorageEvent) => {
-      if (e.key === 'conversationIds' && e.newValue) {
-        setConversations(JSON.parse(e.newValue) as ConversationEntry[])
-      }
+    const loadConversations = () => {
+      getConversations()
+        .then(setConversations)
+        .catch((err: unknown) => {
+          console.error('Failed to load conversations:', err)
+        })
     }
 
-    const handleCustomStorageChange = () => {
-      const stored = window.localStorage.getItem('conversationIds')
-      setConversations(stored ? (JSON.parse(stored) as ConversationEntry[]) : [])
-    }
+    loadConversations()
 
-    window.addEventListener('storage', handleStorageChange)
-    // a custom event to handle same-tab updates
-    window.addEventListener('local-storage-change', handleCustomStorageChange)
+    window.addEventListener('conversations-changed', loadConversations)
 
     return () => {
-      window.removeEventListener('storage', handleStorageChange)
-      window.removeEventListener('local-storage-change', handleCustomStorageChange)
+      window.removeEventListener('conversations-changed', loadConversations)
     }
   }, [])
 
@@ -74,25 +68,16 @@ function doLocalNavigation(e: React.MouseEvent) {
 }
 
 function deleteConversation(conversationId: string) {
-  // Remove from conversationIds list
-  const stored = window.localStorage.getItem('conversationIds')
-  if (stored) {
-    const conversations = JSON.parse(stored) as ConversationEntry[]
-    const updated = conversations.filter((conv) => conv.id !== conversationId)
-    window.localStorage.setItem('conversationIds', JSON.stringify(updated))
-    // Dispatch event to notify other components
-    window.dispatchEvent(new Event('local-storage-change'))
-  }
+  return deleteConv(conversationId).then(() => {
+    window.dispatchEvent(new Event('conversations-changed'))
 
-  // Remove the conversation's messages
-  window.localStorage.removeItem(conversationId)
-
-  // If the deleted conversation was active, navigate to home
-  const currentPath = window.location.pathname
-  if (currentPath === conversationId) {
-    window.history.pushState({}, '', '/')
-    window.dispatchEvent(new Event('history-state-changed'))
-  }
+    // If the deleted conversation was active, navigate to home
+    const currentPath = window.location.pathname
+    if (currentPath === conversationId) {
+      window.history.pushState({}, '', '/')
+      window.dispatchEvent(new Event('history-state-changed'))
+    }
+  })
 }
 
 export function AppSidebar() {
@@ -111,9 +96,15 @@ export function AppSidebar() {
   const handleConfirmDelete = () => {
     if (conversationToDelete) {
       deleteConversation(conversationToDelete.id)
-      setDeleteDialogOpen(false)
-      setConversationToDelete(null)
-      toast.success('Chat deleted successfully')
+        .then(() => {
+          setDeleteDialogOpen(false)
+          setConversationToDelete(null)
+          toast.success('Chat deleted successfully')
+        })
+        .catch((err: unknown) => {
+          console.error('Failed to delete conversation:', err)
+          toast.error('Failed to delete chat')
+        })
     }
   }
 

--- a/src/lib/chat-db.ts
+++ b/src/lib/chat-db.ts
@@ -1,4 +1,6 @@
 import type { ConversationEntry } from '@/types'
+import type { UIMessage } from 'ai'
+import { toast } from 'sonner'
 
 const DB_NAME = 'chat-storage'
 const DB_VERSION = 1
@@ -14,14 +16,19 @@ function openDatabase(): Promise<IDBDatabase> {
     const request = window.indexedDB.open(DB_NAME, DB_VERSION)
 
     request.onerror = () => {
+      dbPromise = null
       reject(new Error(request.error?.message ?? 'Failed to open database'))
     }
     request.onsuccess = () => {
-      resolve(request.result)
+      const db = request.result
+      db.onclose = () => {
+        dbPromise = null
+      }
+      resolve(db)
     }
 
-    request.onupgradeneeded = (event) => {
-      const db = (event.target as IDBOpenDBRequest).result
+    request.onupgradeneeded = () => {
+      const db = request.result
 
       if (!db.objectStoreNames.contains(CONVERSATIONS_STORE)) {
         db.createObjectStore(CONVERSATIONS_STORE, { keyPath: 'id' })
@@ -47,7 +54,8 @@ export async function getConversations(): Promise<ConversationEntry[]> {
       reject(new Error(request.error?.message ?? 'Failed to get conversations'))
     }
     request.onsuccess = () => {
-      const conversations = request.result as ConversationEntry[]
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- IDB getAll() returns untyped data
+      const conversations: ConversationEntry[] = request.result
       conversations.sort((a, b) => b.timestamp - a.timestamp)
       resolve(conversations)
     }
@@ -70,7 +78,7 @@ export async function saveConversation(conversation: ConversationEntry): Promise
       }
     })
   } catch (error) {
-    window.alert('Failed to save conversation. Your browser storage may be full or unavailable.')
+    toast.error('Failed to save conversation. Your browser storage may be full or unavailable.')
     throw error
   }
 }
@@ -95,7 +103,7 @@ export async function deleteConversation(conversationId: string): Promise<void> 
   })
 }
 
-export async function getMessages(conversationId: string): Promise<unknown[] | null> {
+export async function getMessages(conversationId: string): Promise<UIMessage[] | null> {
   const db = await openDatabase()
   return new Promise((resolve, reject) => {
     const tx = db.transaction(MESSAGES_STORE, 'readonly')
@@ -106,13 +114,14 @@ export async function getMessages(conversationId: string): Promise<unknown[] | n
       reject(new Error(request.error?.message ?? 'Failed to get messages'))
     }
     request.onsuccess = () => {
-      const result = request.result as { id: string; messages: unknown[] } | undefined
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- IDB get() returns untyped data
+      const result: { id: string; messages: UIMessage[] } | undefined = request.result
       resolve(result?.messages ?? null)
     }
   })
 }
 
-export async function saveMessages(conversationId: string, messages: unknown[]): Promise<void> {
+export async function saveMessages(conversationId: string, messages: UIMessage[]): Promise<void> {
   try {
     const db = await openDatabase()
     await new Promise<void>((resolve, reject) => {
@@ -128,7 +137,7 @@ export async function saveMessages(conversationId: string, messages: unknown[]):
       }
     })
   } catch (error) {
-    window.alert('Failed to save messages. Your browser storage may be full or unavailable.')
+    toast.error('Failed to save messages. Your browser storage may be full or unavailable.')
     throw error
   }
 }
@@ -145,19 +154,26 @@ export async function migrateFromLocalStorage(): Promise<boolean> {
     return false
   }
 
-  const conversations = JSON.parse(conversationsJson) as ConversationEntry[]
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- JSON.parse returns untyped data
+  const conversations: ConversationEntry[] = JSON.parse(conversationsJson)
+  const migratedKeys: string[] = []
 
   for (const conv of conversations) {
     await saveConversation(conv)
 
     const messagesJson = localStorage.getItem(conv.id)
     if (messagesJson) {
-      const messages = JSON.parse(messagesJson) as unknown[]
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- JSON.parse returns untyped data
+      const messages: UIMessage[] = JSON.parse(messagesJson)
       await saveMessages(conv.id, messages)
-      localStorage.removeItem(conv.id)
+      migratedKeys.push(conv.id)
     }
   }
 
+  // Clean up localStorage only after all IDB writes succeeded
+  for (const key of migratedKeys) {
+    localStorage.removeItem(key)
+  }
   localStorage.removeItem('conversationIds')
   localStorage.setItem(migrationKey, 'true')
 

--- a/src/lib/chat-db.ts
+++ b/src/lib/chat-db.ts
@@ -1,0 +1,165 @@
+import type { ConversationEntry } from '@/types'
+
+const DB_NAME = 'chat-storage'
+const DB_VERSION = 1
+const CONVERSATIONS_STORE = 'conversations'
+const MESSAGES_STORE = 'messages'
+
+let dbPromise: Promise<IDBDatabase> | null = null
+
+function openDatabase(): Promise<IDBDatabase> {
+  if (dbPromise) return dbPromise
+
+  dbPromise = new Promise((resolve, reject) => {
+    const request = window.indexedDB.open(DB_NAME, DB_VERSION)
+
+    request.onerror = () => {
+      reject(new Error(request.error?.message ?? 'Failed to open database'))
+    }
+    request.onsuccess = () => {
+      resolve(request.result)
+    }
+
+    request.onupgradeneeded = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result
+
+      if (!db.objectStoreNames.contains(CONVERSATIONS_STORE)) {
+        db.createObjectStore(CONVERSATIONS_STORE, { keyPath: 'id' })
+      }
+
+      if (!db.objectStoreNames.contains(MESSAGES_STORE)) {
+        db.createObjectStore(MESSAGES_STORE, { keyPath: 'id' })
+      }
+    }
+  })
+
+  return dbPromise
+}
+
+export async function getConversations(): Promise<ConversationEntry[]> {
+  const db = await openDatabase()
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(CONVERSATIONS_STORE, 'readonly')
+    const store = tx.objectStore(CONVERSATIONS_STORE)
+    const request = store.getAll()
+
+    request.onerror = () => {
+      reject(new Error(request.error?.message ?? 'Failed to get conversations'))
+    }
+    request.onsuccess = () => {
+      const conversations = request.result as ConversationEntry[]
+      conversations.sort((a, b) => b.timestamp - a.timestamp)
+      resolve(conversations)
+    }
+  })
+}
+
+export async function saveConversation(conversation: ConversationEntry): Promise<void> {
+  try {
+    const db = await openDatabase()
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(CONVERSATIONS_STORE, 'readwrite')
+      const store = tx.objectStore(CONVERSATIONS_STORE)
+      const request = store.put(conversation)
+
+      request.onerror = () => {
+        reject(new Error(request.error?.message ?? 'Failed to save conversation'))
+      }
+      request.onsuccess = () => {
+        resolve()
+      }
+    })
+  } catch (error) {
+    window.alert('Failed to save conversation. Your browser storage may be full or unavailable.')
+    throw error
+  }
+}
+
+export async function deleteConversation(conversationId: string): Promise<void> {
+  const db = await openDatabase()
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction([CONVERSATIONS_STORE, MESSAGES_STORE], 'readwrite')
+
+    const convStore = tx.objectStore(CONVERSATIONS_STORE)
+    convStore.delete(conversationId)
+
+    const msgStore = tx.objectStore(MESSAGES_STORE)
+    msgStore.delete(conversationId)
+
+    tx.oncomplete = () => {
+      resolve()
+    }
+    tx.onerror = () => {
+      reject(new Error(tx.error?.message ?? 'Failed to delete conversation'))
+    }
+  })
+}
+
+export async function getMessages(conversationId: string): Promise<unknown[] | null> {
+  const db = await openDatabase()
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(MESSAGES_STORE, 'readonly')
+    const store = tx.objectStore(MESSAGES_STORE)
+    const request = store.get(conversationId)
+
+    request.onerror = () => {
+      reject(new Error(request.error?.message ?? 'Failed to get messages'))
+    }
+    request.onsuccess = () => {
+      const result = request.result as { id: string; messages: unknown[] } | undefined
+      resolve(result?.messages ?? null)
+    }
+  })
+}
+
+export async function saveMessages(conversationId: string, messages: unknown[]): Promise<void> {
+  try {
+    const db = await openDatabase()
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(MESSAGES_STORE, 'readwrite')
+      const store = tx.objectStore(MESSAGES_STORE)
+      const request = store.put({ id: conversationId, messages })
+
+      request.onerror = () => {
+        reject(new Error(request.error?.message ?? 'Failed to save messages'))
+      }
+      request.onsuccess = () => {
+        resolve()
+      }
+    })
+  } catch (error) {
+    window.alert('Failed to save messages. Your browser storage may be full or unavailable.')
+    throw error
+  }
+}
+
+export async function migrateFromLocalStorage(): Promise<boolean> {
+  const migrationKey = 'indexeddb-migration-complete'
+  if (localStorage.getItem(migrationKey)) {
+    return false
+  }
+
+  const conversationsJson = localStorage.getItem('conversationIds')
+  if (!conversationsJson) {
+    localStorage.setItem(migrationKey, 'true')
+    return false
+  }
+
+  const conversations = JSON.parse(conversationsJson) as ConversationEntry[]
+
+  for (const conv of conversations) {
+    await saveConversation(conv)
+
+    const messagesJson = localStorage.getItem(conv.id)
+    if (messagesJson) {
+      const messages = JSON.parse(messagesJson) as unknown[]
+      await saveMessages(conv.id, messages)
+      localStorage.removeItem(conv.id)
+    }
+  }
+
+  localStorage.removeItem('conversationIds')
+  localStorage.setItem(migrationKey, 'true')
+
+  return true
+}


### PR DESCRIPTION
IndexedDB is unlimited.

Maybe I should also implement warnings for when the chat crosses certain thresholds so you remember to delete your chats and not waste disk space? Let me know if you want that as a fast-follow PR.

But the old way was a hard limit that would crash a demo in the middle.

Fixes https://github.com/pydantic/ai-chat-ui/issues/17
