### PR TITLE
feat: support sub-path deployment for preview URLs

### DIFF
--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -28,6 +28,7 @@ import { useConversationIdFromUrl } from './hooks/useConversationIdFromUrl'
 import { Part } from './Part'
 import { getToolIcon } from '@/lib/tool-icons'
 import { getMessages, saveMessages, saveConversation } from '@/lib/chat-db'
+import { stripBasePath, withBasePath } from '@/lib/base-path'
 
 interface ModelConfig {
   id: string
@@ -94,13 +95,13 @@ const Chat = () => {
       const theCurrentUrl = new URL(window.location.toString())
 
       // we're starting a new conversation
-      if (theCurrentUrl.pathname === '/') {
+      if (stripBasePath(theCurrentUrl.pathname) === '/') {
         const newConversationId = `/${nanoid()}`
         setConversationId(newConversationId)
 
         saveConversationEntry(newConversationId, input)
 
-        theCurrentUrl.pathname = newConversationId
+        theCurrentUrl.pathname = withBasePath(newConversationId)
         window.history.pushState({}, '', theCurrentUrl.toString())
       }
 

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -29,6 +29,7 @@ import { useConversationIdFromUrl } from '@/hooks/useConversationIdFromUrl'
 import { cn } from '@/lib/utils'
 import type { ConversationEntry } from '@/types'
 import { getConversations, deleteConversation as deleteConv } from '@/lib/chat-db'
+import { stripBasePath, withBasePath } from '@/lib/base-path'
 import { ModeToggle } from './mode-toggle'
 import logoSvg from '../assets/logo.svg'
 
@@ -71,10 +72,9 @@ function deleteConversation(conversationId: string) {
   return deleteConv(conversationId).then(() => {
     window.dispatchEvent(new Event('conversations-changed'))
 
-    // If the deleted conversation was active, navigate to home
-    const currentPath = window.location.pathname
+    const currentPath = stripBasePath(window.location.pathname)
     if (currentPath === conversationId) {
-      window.history.pushState({}, '', '/')
+      window.history.pushState({}, '', withBasePath('/'))
       window.dispatchEvent(new Event('history-state-changed'))
     }
   })
@@ -126,7 +126,7 @@ export function AppSidebar() {
             <SidebarMenu className="mb-2">
               <SidebarMenuItem>
                 <SidebarMenuButton asChild tooltip="Start a new conversation">
-                  <a href="/" onClick={doLocalNavigation}>
+                  <a href={withBasePath('/')} onClick={doLocalNavigation}>
                     <CirclePlus />
                     <span>New conversation</span>
                   </a>
@@ -141,7 +141,7 @@ export function AppSidebar() {
                     <div className="flex items-center gap-1 h-auto">
                       <SidebarMenuButton asChild tooltip={conversation.firstMessage} className="flex-1">
                         <a
-                          href={conversation.id}
+                          href={withBasePath(conversation.id)}
                           onClick={doLocalNavigation}
                           className={cn('h-auto flex items-start gap-2', {
                             'bg-accent pointer-events-none': conversation.id === conversationId,

--- a/src/hooks/useConversationIdFromUrl.tsx
+++ b/src/hooks/useConversationIdFromUrl.tsx
@@ -1,13 +1,14 @@
 import { useState, useEffect } from 'react'
+import { stripBasePath, withBasePath } from '@/lib/base-path'
 
 export function useConversationIdFromUrl(): [string, (id: string) => void] {
   const [conversationId, setConversationId] = useState(() => {
-    return window.location.pathname
+    return stripBasePath(window.location.pathname)
   })
 
   useEffect(() => {
     const handlePopState = () => {
-      const newId = window.location.pathname
+      const newId = stripBasePath(window.location.pathname)
       console.log('popstate event detected', window.location.pathname)
       setConversationId(newId)
     }
@@ -24,7 +25,7 @@ export function useConversationIdFromUrl(): [string, (id: string) => void] {
   const setConversationIdAndUrl = (id: string) => {
     setConversationId(id)
     const url = new URL(window.location.toString())
-    url.pathname = id || '/'
+    url.pathname = withBasePath(id || '/')
     window.history.pushState({}, '', url.toString())
   }
 

--- a/src/lib/base-path.ts
+++ b/src/lib/base-path.ts
@@ -1,0 +1,14 @@
+const RAW = import.meta.env.BASE_URL
+const BASE = RAW.startsWith('http') ? '/' : RAW.endsWith('/') ? RAW : RAW + '/'
+
+export function stripBasePath(pathname: string): string {
+  if (BASE === '/') return pathname
+  if (pathname.startsWith(BASE)) return '/' + pathname.slice(BASE.length)
+  return pathname
+}
+
+export function withBasePath(appPath: string): string {
+  if (BASE === '/') return appPath
+  const stripped = appPath.startsWith('/') ? appPath.slice(1) : appPath
+  return BASE + stripped
+}


### PR DESCRIPTION
## Summary

- Adds `stripBasePath` / `withBasePath` utilities that use `import.meta.env.BASE_URL` to handle sub-path mounting (e.g. `/preview/main/`)
- Wraps all client-side pathname reads/writes so routing works when the app is served at a sub-path
- When `BASE_URL` is `/` (standalone deployment), both functions are identity — zero behavioral change

## Changes

- **New:** `src/lib/base-path.ts` — 14-line utility
- **Modified:** `src/hooks/useConversationIdFromUrl.tsx` — strip/prepend base on read/write
- **Modified:** `src/Chat.tsx` — strip base before checking `'/'`, prepend base on new conversation URL
- **Modified:** `src/components/app-sidebar.tsx` — prepend base on sidebar links, strip base in delete comparison

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run build` with default config — assets reference `/` (standalone unchanged)
- [x] `pnpm vite build --base /preview/test/` — `index.html` has `/preview/test/assets/...`
- [x] `pnpm vite preview --base /preview/test/` — app renders and routes correctly at `/preview/test/`
- [ ] Deploy via webui.pydantic.work to validate end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)