### PR TITLE
feat: add Playwright E2E tests and CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,36 @@ jobs:
 
       - name: Lint
         run: pnpm run lint
+
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "lts/*"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install chromium --with-deps
+
+      - name: Run E2E tests
+        run: pnpm exec playwright test
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ dist-ssr
 /tsconfig.tsbuildinfo
 .env
 *.tgz
+/test-results/
+/playwright-report/

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "dev": "BACKEND_PORT=38001 vite",
     "dev:server": "cd agent && uv run uvicorn chatbot.server:app --port 38001",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "playwright test",
+    "test:ui": "playwright test --ui"
   },
   "files": [
     "dist"
@@ -65,6 +67,7 @@
     "@commitlint/cli": "^20.3.1",
     "@commitlint/config-conventional": "^20.3.1",
     "@eslint/js": "^9.39.2",
+    "@playwright/test": "^1.59.1",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/npm": "^13.1.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:54321',
+    trace: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'pnpm vite --port 54321',
+    url: 'http://localhost:54321',
+    reuseExistingServer: !process.env.CI,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.2
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@semantic-release/changelog':
         specifier: ^6.0.3
         version: 6.0.3(semantic-release@25.0.3(typescript@5.8.3))
@@ -979,6 +982,11 @@ packages:
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -3173,6 +3181,11 @@ packages:
     resolution: {integrity: sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==}
     engines: {node: '>=14.14'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4572,6 +4585,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   points-on-curve@0.2.0:
     resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
@@ -6346,6 +6369,10 @@ snapshots:
   '@opentelemetry/api@1.9.0': {}
 
   '@pkgr/core@0.2.9': {}
+
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -8765,6 +8792,9 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -10346,6 +10376,14 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.0
       pathe: 2.0.3
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   points-on-curve@0.2.0: {}
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,0 +1,30 @@
+# Testing Standards
+
+## Selectors
+- Prefer accessible selectors: `getByRole`, `getByPlaceholder`, `getByText`, `getByLabel`
+- Use `data-testid` only when no semantic selector exists
+- Never use CSS selectors or XPath
+
+## Test isolation
+- Each test gets a fresh browser context (Playwright default)
+- Tests must not depend on each other or share state
+- Clean up IndexedDB between tests if persistence bleeds
+
+## Mocking
+- All API calls are mocked via `page.route()` in `tests/e2e/mocks.ts`
+- Mock responses must match the real API shape — update mocks when API changes
+- Never call real LLM APIs in tests
+
+## Assertions
+- Use web-first assertions (`expect(locator).toBeVisible()`) — they auto-retry
+- Never use `page.waitForTimeout()` — use `expect` with auto-retry or `page.waitForSelector`
+- Assert on user-visible outcomes, not implementation details
+
+## Naming
+- Test files: `*.test.ts` in `tests/e2e/`
+- Describe blocks: feature area (e.g., "chat", "sidebar", "persistence")
+- Test names: describe user behavior, not implementation ("sends a message and sees response")
+
+## When to add tests
+- Every new user-facing feature needs at least one E2E test
+- Bug fixes should include a regression test when feasible

--- a/tests/e2e/chat.test.ts
+++ b/tests/e2e/chat.test.ts
@@ -1,0 +1,92 @@
+import { test, expect } from '@playwright/test'
+import { setupMocks } from './mocks'
+
+const sidebar = '[data-sidebar="sidebar"]'
+
+test.beforeEach(async ({ page }) => {
+  await setupMocks(page)
+})
+
+test.describe('chat', () => {
+  test('app loads with sidebar and chat input', async ({ page }) => {
+    await page.goto('/')
+
+    await expect(page.getByText('New conversation')).toBeVisible()
+    await expect(page.getByPlaceholder('What would you like to know?')).toBeVisible()
+  })
+
+  test('sends a message and sees assistant response', async ({ page }) => {
+    await page.goto('/')
+
+    const input = page.getByPlaceholder('What would you like to know?')
+    await input.fill('Hello there')
+    await input.press('Enter')
+
+    const chat = page.getByRole('log')
+    await expect(chat.getByText('Hello there')).toBeVisible()
+    await expect(chat.getByText('This is a mock response from the assistant.')).toBeVisible()
+  })
+
+  test('conversation appears in sidebar after sending', async ({ page }) => {
+    await page.goto('/')
+
+    const input = page.getByPlaceholder('What would you like to know?')
+    await input.fill('My sidebar test message')
+    await input.press('Enter')
+
+    await expect(page.getByRole('log').getByText('This is a mock response from the assistant.')).toBeVisible()
+
+    // Sidebar should show the conversation entry with truncated first message
+    await expect(page.locator(sidebar).getByText('My sidebar test message')).toBeVisible()
+  })
+
+  test('navigates between conversations', async ({ page }) => {
+    await page.goto('/')
+
+    // Send message in conversation A
+    const input = page.getByPlaceholder('What would you like to know?')
+    await input.fill('Conversation A message')
+    await input.press('Enter')
+    await expect(page.getByRole('log').getByText('This is a mock response from the assistant.')).toBeVisible()
+
+    // Wait for throttled save (useThrottle 500ms) to flush to IndexedDB
+    await page.waitForTimeout(600)
+
+    // Start conversation B
+    await page.locator(sidebar).getByText('New conversation').click()
+    await expect(page.getByPlaceholder('What would you like to know?')).toBeVisible()
+
+    await page.getByPlaceholder('What would you like to know?').fill('Conversation B message')
+    await page.getByPlaceholder('What would you like to know?').press('Enter')
+    await expect(page.getByRole('log').getByText('Conversation B message')).toBeVisible()
+
+    // Navigate back to conversation A via sidebar
+    await page.locator(sidebar).getByText('Conversation A message').click()
+
+    // Conversation A messages should reload from IndexedDB
+    await expect(page.getByRole('log').getByText('Conversation A message')).toBeVisible()
+  })
+
+  test('messages persist after hard refresh', async ({ page }) => {
+    await page.goto('/')
+
+    const input = page.getByPlaceholder('What would you like to know?')
+    await input.fill('Persistence test message')
+    await input.press('Enter')
+
+    await expect(page.getByRole('log').getByText('This is a mock response from the assistant.')).toBeVisible()
+
+    // Wait for throttled save (500ms) to complete
+    await page.waitForTimeout(600)
+
+    // Hard refresh
+    await page.reload()
+
+    // Re-apply mocks after reload (route handlers are cleared on navigation)
+    await setupMocks(page)
+
+    // Messages should load back from IndexedDB
+    await expect(page.getByRole('log').getByText('Persistence test message')).toBeVisible()
+    await expect(page.getByRole('log').getByText('This is a mock response from the assistant.')).toBeVisible()
+  })
+})

--- a/tests/e2e/mocks.ts
+++ b/tests/e2e/mocks.ts
@@ -1,0 +1,64 @@
+import type { Page } from '@playwright/test'
+
+const CONFIGURE_RESPONSE = {
+  models: [
+    {
+      id: 'test-model',
+      name: 'Test Model',
+      builtinTools: ['web_search'],
+    },
+  ],
+  builtinTools: [
+    {
+      name: 'Web Search',
+      id: 'web_search',
+    },
+  ],
+}
+
+/**
+ * Build an AI SDK v5 UI message stream response body (SSE format).
+ *
+ * Protocol: each event is `data: <json>\n\n`, terminated by `data: [DONE]\n\n`
+ * Header: `X-Vercel-AI-UI-Message-Stream: v1`, `Content-Type: text/event-stream`
+ *
+ * Event types for text: text-start, text-delta, text-end
+ */
+function buildStreamBody(text: string, partId = 'aitxt_mock000000000000001'): string {
+  const events = [
+    `data: ${JSON.stringify({ type: 'text-start', id: partId })}`,
+    `data: ${JSON.stringify({ type: 'text-delta', id: partId, delta: text })}`,
+    `data: ${JSON.stringify({ type: 'text-end', id: partId })}`,
+    'data: [DONE]',
+  ]
+  return events.join('\n\n') + '\n\n'
+}
+
+let chatCallCount = 0
+
+export async function setupMocks(page: Page, responseText = 'This is a mock response from the assistant.') {
+  chatCallCount = 0
+
+  await page.route('**/api/configure', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(CONFIGURE_RESPONSE),
+    }),
+  )
+
+  await page.route('**/api/chat', (route) => {
+    chatCallCount++
+    const partId = `aitxt_mock${String(chatCallCount).padStart(18, '0')}`
+    return route.fulfill({
+      status: 200,
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+        'X-Vercel-AI-UI-Message-Stream': 'v1',
+      },
+      body: buildStreamBody(responseText, partId),
+    })
+  })
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,5 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src", "eslint.config.ts", "vite.config.ts"]
+  "include": ["src", "tests", "eslint.config.ts", "vite.config.ts", "playwright.config.ts"]
 }


### PR DESCRIPTION
## Summary

- Add 5 Playwright E2E tests covering core chat flows: app load, send/receive messages, sidebar conversation entries, navigation between conversations, and IndexedDB persistence across hard refresh
- All API calls mocked via `page.route()` — tests run without the Python backend
- Add parallel `e2e` CI job with Playwright report artifact upload on failure
- Add `pnpm test` and `pnpm test:ui` scripts

## Test plan

- [x] `pnpm test` — all 5 tests pass locally
- [x] `pnpm run typecheck` — passes
- [x] `pnpm eslint tests/ playwright.config.ts` — passes
- [ ] CI runs both `ci` and `e2e` jobs in parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)