### PR TITLE
feat: tool approval UI for AI SDK v6

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,12 @@ File names are kebab-case (`tool-approval-prompt.tsx`); exported component names
 
 `src/Chat.tsx` and `src/Part.tsx` are top-level composition orchestrators; the pieces they render belong in their own files.
 
+### Vendored components are read-only
+
+`src/components/ui/` (shadcn) and `src/components/ai-elements/` (Vercel AI Elements) are vendored from upstream registries. Treat them as read-only: never modify in place. To customize behavior, wrap the primitive in a new file under `src/components/`. To upgrade, re-run `npx shadcn@latest add <name>` (or `@ai-elements/<name>`) and review the diff.
+
+A small number of pre-existing local modifications survive in these folders (e.g. the Dialog-based error display in `ai-elements/tool.tsx` from #11). Each is tagged with a `// local modification:` comment. Leave those as they are, but don't add new ones — extract a wrapper instead.
+
 ## Configuration
 
 - **TypeScript paths**: `@/*` maps to `./src/*`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,20 @@ Note: Stop any logfire platform instances to avoid port 8000 conflicts.
 - Enabled per-model in AI_MODELS configuration
 - Selected tools passed to agent via `VercelAIAdapter.dispatch_request`
 
+## Frontend code structure
+
+### One component per file
+
+Non-trivial React components live in their own file. Trivial means: pure JSX, no state/effects, used in exactly one place, ~10 lines or fewer — those can be inline functions in the parent file. Everything else gets its own file.
+
+File names are kebab-case (`tool-approval-prompt.tsx`); exported component names are PascalCase (`ToolApprovalPrompt`). Place files under:
+
+- `src/components/{name}.tsx` — domain-specific compositions (`edit-message-dialog.tsx`, `tool-approval-prompt.tsx`)
+- `src/components/ai-elements/{name}.tsx` — wrappers around `@ai-sdk` UI elements (`confirmation.tsx`, `tool.tsx`)
+- `src/components/ui/{name}.tsx` — pure shadcn/ui primitives (`button.tsx`, `alert.tsx`)
+
+`src/Chat.tsx` and `src/Part.tsx` are top-level composition orchestrators; the pieces they render belong in their own files.
+
 ## Configuration
 
 - **TypeScript paths**: `@/*` maps to `./src/*`

--- a/components.json
+++ b/components.json
@@ -18,5 +18,7 @@
     "lib": "@/lib",
     "hooks": "@/hooks"
   },
-  "registries": {}
+  "registries": {
+    "@ai-elements": "https://ai-sdk.dev/elements/api/registry/{name}.json"
+  }
 }

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -45,6 +45,7 @@ export default defineConfig(
         },
       ],
       '@typescript-eslint/no-non-null-assertion': 'off',
+      'no-void': ['error', { allowAsStatement: true }],
     },
   },
   {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,17 @@
 import { defineConfig, devices } from '@playwright/test'
 
+// Local-dev shim for HTTP firewalls (e.g. Socket Firewall) that set
+// HTTP_PROXY=http://127.0.0.1:<port>. Without bypassing loopback, Playwright's
+// URL probe for the dev server gets routed through the proxy and returns 405,
+// so the webServer wait times out. Harmless when no proxy is configured.
+const LOOPBACK = ['localhost', '127.0.0.1', '::1']
+const noProxy = (process.env.NO_PROXY ?? '').split(',').filter(Boolean)
+for (const host of LOOPBACK) {
+  if (!noProxy.includes(host)) noProxy.push(host)
+}
+process.env.NO_PROXY = noProxy.join(',')
+process.env.no_proxy = process.env.NO_PROXY
+
 export default defineConfig({
   testDir: './tests/e2e',
   fullyParallel: true,
@@ -8,7 +20,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
   use: {
-    baseURL: 'http://localhost:54321',
+    baseURL: 'http://127.0.0.1:54321',
     trace: 'retain-on-failure',
   },
   projects: [
@@ -18,8 +30,10 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'pnpm vite --port 54321',
-    url: 'http://localhost:54321',
+    // Vite's default host on macOS binds IPv6-only, so Playwright's IPv4 probe times out.
+    // Pin to 127.0.0.1 so probe + bind agree across macOS / Linux CI.
+    command: 'pnpm vite --port 54321 --host 127.0.0.1',
+    url: 'http://127.0.0.1:54321',
     reuseExistingServer: !process.env.CI,
   },
 })

--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -19,6 +19,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/compon
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { Switch } from '@/components/ui/switch'
 import { useChat } from '@ai-sdk/react'
+import { DefaultChatTransport, lastAssistantMessageIsCompleteWithApprovalResponses } from 'ai'
 import { Settings2Icon } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState, type SyntheticEvent } from 'react'
 
@@ -58,7 +59,21 @@ const Chat = () => {
   const [input, setInput] = useState('')
   const [model, setModel] = useState('')
   const [enabledTools, setEnabledTools] = useState<string[]>([])
-  const { messages, sendMessage, status, setMessages, regenerate, error } = useChat()
+  const modelRef = useRef(model)
+  modelRef.current = model
+  const enabledToolsRef = useRef(enabledTools)
+  enabledToolsRef.current = enabledTools
+
+  const [transport] = useState(
+    () =>
+      new DefaultChatTransport({
+        body: () => ({ model: modelRef.current, builtinTools: enabledToolsRef.current }),
+      }),
+  )
+  const { messages, sendMessage, status, setMessages, regenerate, error, addToolApprovalResponse } = useChat({
+    transport,
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
+  })
   const throttledMessages = useThrottle(messages, 500)
   const [conversationId, setConversationId] = useConversationIdFromUrl()
   const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -123,12 +138,7 @@ const Chat = () => {
         window.history.pushState({}, '', theCurrentUrl.toString())
       }
 
-      sendMessage(
-        { text: input },
-        {
-          body: { model, builtinTools: enabledTools },
-        },
-      ).catch((error: unknown) => {
+      sendMessage({ text: input }).catch((error: unknown) => {
         console.error('Error sending message:', error)
       })
       setInput('')
@@ -140,11 +150,9 @@ const Chat = () => {
     if (!pendingSendRef.current) return
     const pending = pendingSendRef.current
     pendingSendRef.current = null
-    sendMessage({ text: pending.text }, { body: { model: pending.model, builtinTools: pending.builtinTools } }).catch(
-      (error: unknown) => {
-        console.error('Error sending deferred message:', error)
-      },
-    )
+    sendMessage({ text: pending.text }).catch((error: unknown) => {
+      console.error('Error sending deferred message:', error)
+    })
   }, [sendTrigger])
 
   useEffect(() => {
@@ -269,6 +277,7 @@ const Chat = () => {
                   index={i}
                   regen={regen}
                   lastMessage={message.id === messages.at(-1)?.id}
+                  onApprovalResponse={addToolApprovalResponse}
                   isEditing={editingMessageId === message.id}
                   editDraft={editDraftsRef.current.get(message.id)}
                   onStartEdit={handleStartEdit}

--- a/src/Part.tsx
+++ b/src/Part.tsx
@@ -11,11 +11,12 @@ import {
   RefreshCcwIcon,
   XIcon,
 } from 'lucide-react'
-import type { UIDataTypes, UIMessagePart, UITools, UIMessage } from 'ai'
+import type { ChatAddToolApproveResponseFunction, UIDataTypes, UIMessagePart, UITools, UIMessage } from 'ai'
 import { useEffect, useState } from 'react'
 import { useForkSiblings } from '@/hooks/useForkSiblings'
 import { Reasoning, ReasoningContent, ReasoningTrigger } from '@/components/ai-elements/reasoning'
 import { Tool, ToolHeader, ToolInput, ToolOutput, ToolContent } from '@/components/ai-elements/tool'
+import { ToolApprovalPrompt } from '@/components/tool-approval-prompt'
 import { CodeBlock } from '@/components/ai-elements/code-block'
 
 interface PartProps {
@@ -25,6 +26,7 @@ interface PartProps {
   regen: (id: string) => void
   index: number
   lastMessage: boolean
+  onApprovalResponse: ChatAddToolApproveResponseFunction
   isEditing?: boolean
   editDraft?: string
   onStartEdit?: (messageId: string) => void
@@ -42,6 +44,7 @@ export function Part({
   regen,
   index,
   lastMessage,
+  onApprovalResponse,
   isEditing,
   editDraft,
   onStartEdit,
@@ -178,14 +181,33 @@ export function Part({
       </Reasoning>
     )
   } else if (part.type === 'dynamic-tool') {
-    return <>Dynamic Tool, TODO {JSON.stringify(part)}</>
-  } else if ('toolCallId' in part) {
-    // return <div>{JSON.stringify(part)}</div>
     return (
-      <Tool>
+      <Tool data-tool-name={part.toolName} defaultOpen={part.state === 'approval-requested'}>
+        <ToolHeader type={part.type} state={part.state} toolName={part.toolName} />
+        <ToolContent>
+          <ToolInput input={part.input} />
+          {'approval' in part && part.approval && (
+            <ToolApprovalPrompt approval={part.approval} state={part.state} onApprovalResponse={onApprovalResponse} />
+          )}
+          {(part.state === 'output-available' || part.state === 'output-error') && (
+            <ToolOutput
+              errorText={part.errorText}
+              output={<CodeBlock code={JSON.stringify(part.output, null, 2)} language="json" />}
+            />
+          )}
+        </ToolContent>
+      </Tool>
+    )
+  } else if ('toolCallId' in part) {
+    const toolId = part.type.split('-').slice(1).join('-')
+    return (
+      <Tool data-tool-name={toolId} defaultOpen={part.state === 'approval-requested'}>
         <ToolHeader type={part.type} state={part.state} />
         <ToolContent>
           <ToolInput input={part.input} />
+          {'approval' in part && part.approval && (
+            <ToolApprovalPrompt approval={part.approval} state={part.state} onApprovalResponse={onApprovalResponse} />
+          )}
           {(part.state === 'output-available' || part.state === 'output-error') && (
             <ToolOutput
               errorText={part.errorText}

--- a/src/Part.tsx
+++ b/src/Part.tsx
@@ -15,9 +15,7 @@ import type { ChatAddToolApproveResponseFunction, UIDataTypes, UIMessagePart, UI
 import { useEffect, useState } from 'react'
 import { useForkSiblings } from '@/hooks/useForkSiblings'
 import { Reasoning, ReasoningContent, ReasoningTrigger } from '@/components/ai-elements/reasoning'
-import { Tool, ToolHeader, ToolInput, ToolOutput, ToolContent } from '@/components/ai-elements/tool'
-import { ToolApprovalPrompt } from '@/components/tool-approval-prompt'
-import { CodeBlock } from '@/components/ai-elements/code-block'
+import { ToolPart } from '@/components/tool-part'
 
 interface PartProps {
   part: UIMessagePart<UIDataTypes, UITools>
@@ -180,43 +178,8 @@ export function Part({
         <ReasoningContent>{part.text}</ReasoningContent>
       </Reasoning>
     )
-  } else if (part.type === 'dynamic-tool') {
-    return (
-      <Tool data-tool-name={part.toolName} defaultOpen={part.state === 'approval-requested'}>
-        <ToolHeader type={part.type} state={part.state} toolName={part.toolName} />
-        <ToolContent>
-          <ToolInput input={part.input} />
-          {'approval' in part && part.approval && (
-            <ToolApprovalPrompt approval={part.approval} state={part.state} onApprovalResponse={onApprovalResponse} />
-          )}
-          {(part.state === 'output-available' || part.state === 'output-error') && (
-            <ToolOutput
-              errorText={part.errorText}
-              output={<CodeBlock code={JSON.stringify(part.output, null, 2)} language="json" />}
-            />
-          )}
-        </ToolContent>
-      </Tool>
-    )
-  } else if ('toolCallId' in part) {
-    const toolId = part.type.split('-').slice(1).join('-')
-    return (
-      <Tool data-tool-name={toolId} defaultOpen={part.state === 'approval-requested'}>
-        <ToolHeader type={part.type} state={part.state} />
-        <ToolContent>
-          <ToolInput input={part.input} />
-          {'approval' in part && part.approval && (
-            <ToolApprovalPrompt approval={part.approval} state={part.state} onApprovalResponse={onApprovalResponse} />
-          )}
-          {(part.state === 'output-available' || part.state === 'output-error') && (
-            <ToolOutput
-              errorText={part.errorText}
-              output={<CodeBlock code={JSON.stringify(part.output, null, 2)} language="json" />}
-            />
-          )}
-        </ToolContent>
-      </Tool>
-    )
+  } else if (part.type === 'dynamic-tool' || 'toolCallId' in part) {
+    return <ToolPart part={part} onApprovalResponse={onApprovalResponse} />
   }
 }
 

--- a/src/components/ai-elements/confirmation.tsx
+++ b/src/components/ai-elements/confirmation.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import type { ToolUIPart } from 'ai'
+import type { ComponentProps, ReactNode } from 'react'
+import { createContext, useContext, useMemo } from 'react'
+
+type ToolUIPartApproval =
+  | {
+      id: string
+      approved?: never
+      reason?: never
+    }
+  | {
+      id: string
+      approved: boolean
+      reason?: string
+    }
+  | {
+      id: string
+      approved: true
+      reason?: string
+    }
+  | {
+      id: string
+      approved: false
+      reason?: string
+    }
+  | undefined
+
+interface ConfirmationContextValue {
+  approval: ToolUIPartApproval
+  state: ToolUIPart['state']
+}
+
+const ConfirmationContext = createContext<ConfirmationContextValue | null>(null)
+
+const useConfirmation = () => {
+  const context = useContext(ConfirmationContext)
+
+  if (!context) {
+    throw new Error('Confirmation components must be used within Confirmation')
+  }
+
+  return context
+}
+
+export type ConfirmationProps = ComponentProps<typeof Alert> & {
+  approval?: ToolUIPartApproval
+  state: ToolUIPart['state']
+}
+
+export const Confirmation = ({ className, approval, state, ...props }: ConfirmationProps) => {
+  const contextValue = useMemo(() => ({ approval, state }), [approval, state])
+
+  if (!approval || state === 'input-streaming' || state === 'input-available') {
+    return null
+  }
+
+  return (
+    <ConfirmationContext.Provider value={contextValue}>
+      <Alert className={cn('flex flex-col gap-2', className)} {...props} />
+    </ConfirmationContext.Provider>
+  )
+}
+
+export type ConfirmationTitleProps = ComponentProps<typeof AlertDescription>
+
+export const ConfirmationTitle = ({ className, ...props }: ConfirmationTitleProps) => (
+  <AlertDescription className={cn('inline', className)} {...props} />
+)
+
+export interface ConfirmationRequestProps {
+  children?: ReactNode
+}
+
+export const ConfirmationRequest = ({ children }: ConfirmationRequestProps) => {
+  const { state } = useConfirmation()
+
+  // Only show when approval is requested
+  if (state !== 'approval-requested') {
+    return null
+  }
+
+  return children
+}
+
+export interface ConfirmationAcceptedProps {
+  children?: ReactNode
+}
+
+export const ConfirmationAccepted = ({ children }: ConfirmationAcceptedProps) => {
+  const { approval, state } = useConfirmation()
+
+  // Only show when approved and in response states
+  if (
+    !approval?.approved ||
+    (state !== 'approval-responded' && state !== 'output-denied' && state !== 'output-available')
+  ) {
+    return null
+  }
+
+  return children
+}
+
+export interface ConfirmationRejectedProps {
+  children?: ReactNode
+}
+
+export const ConfirmationRejected = ({ children }: ConfirmationRejectedProps) => {
+  const { approval, state } = useConfirmation()
+
+  // Only show when rejected and in response states
+  if (
+    approval?.approved !== false ||
+    (state !== 'approval-responded' && state !== 'output-denied' && state !== 'output-available')
+  ) {
+    return null
+  }
+
+  return children
+}
+
+export type ConfirmationActionsProps = ComponentProps<'div'>
+
+export const ConfirmationActions = ({ className, ...props }: ConfirmationActionsProps) => {
+  const { state } = useConfirmation()
+
+  // Only show when approval is requested
+  if (state !== 'approval-requested') {
+    return null
+  }
+
+  return <div className={cn('flex items-center justify-end gap-2 self-end', className)} {...props} />
+}
+
+export type ConfirmationActionProps = ComponentProps<typeof Button>
+
+export const ConfirmationAction = (props: ConfirmationActionProps) => (
+  <Button className="h-8 px-3 text-sm" type="button" {...props} />
+)

--- a/src/components/ai-elements/tool.tsx
+++ b/src/components/ai-elements/tool.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
-import type { ToolUIPart } from 'ai'
+import type { DynamicToolUIPart, ToolUIPart } from 'ai'
 import {
   CheckCircleIcon,
   ChevronDownIcon,
@@ -19,19 +19,20 @@ import { useState, type ComponentProps, type ReactNode } from 'react'
 import { CodeBlock } from './code-block'
 import { getToolIcon } from '@/lib/tool-icons'
 
+export type ToolPart = ToolUIPart | DynamicToolUIPart
+
 export type ToolProps = ComponentProps<typeof Collapsible>
 
 export const Tool = ({ className, ...props }: ToolProps) => (
   <Collapsible className={cn('not-prose mb-4 w-full rounded-md border', className)} {...props} />
 )
 
-export interface ToolHeaderProps {
-  type: ToolUIPart['type']
-  state: ToolUIPart['state']
+export type ToolHeaderProps = {
+  state: ToolPart['state']
   className?: string
-}
+} & ({ type: ToolUIPart['type']; toolName?: never } | { type: 'dynamic-tool'; toolName: string })
 
-const getStatusBadge = (status: ToolUIPart['state']) => {
+const getStatusBadge = (status: ToolPart['state']) => {
   const labels = {
     'input-streaming': 'Pending',
     'input-available': 'Running',
@@ -60,8 +61,8 @@ const getStatusBadge = (status: ToolUIPart['state']) => {
   )
 }
 
-export const ToolHeader = ({ className, type, state, ...props }: ToolHeaderProps) => {
-  const toolId = type.slice(5) // Remove 'tool-' prefix
+export const ToolHeader = ({ className, type, state, toolName, ...props }: ToolHeaderProps) => {
+  const toolId = type === 'dynamic-tool' ? toolName : type.slice(5)
   const toolIcon = getToolIcon(toolId, 'size-4 text-muted-foreground')
 
   return (
@@ -89,7 +90,7 @@ export const ToolContent = ({ className, ...props }: ToolContentProps) => (
 )
 
 export type ToolInputProps = ComponentProps<'div'> & {
-  input: ToolUIPart['input']
+  input: ToolPart['input']
 }
 
 export const ToolInput = ({ className, input, ...props }: ToolInputProps) => (
@@ -103,7 +104,7 @@ export const ToolInput = ({ className, input, ...props }: ToolInputProps) => (
 
 export type ToolOutputProps = ComponentProps<'div'> & {
   output: ReactNode
-  errorText: ToolUIPart['errorText']
+  errorText: ToolPart['errorText']
 }
 
 export const ToolOutput = ({ className, output, errorText, ...props }: ToolOutputProps) => {

--- a/src/components/tool-approval-prompt.tsx
+++ b/src/components/tool-approval-prompt.tsx
@@ -1,0 +1,45 @@
+import {
+  Confirmation,
+  ConfirmationAction,
+  ConfirmationActions,
+  ConfirmationAccepted,
+  ConfirmationRejected,
+  ConfirmationRequest,
+  ConfirmationTitle,
+} from '@/components/ai-elements/confirmation'
+import type { ChatAddToolApproveResponseFunction } from 'ai'
+
+interface ToolApprovalPromptProps {
+  approval: { id: string }
+  state: 'approval-requested' | 'approval-responded' | 'output-available' | 'output-denied' | 'output-error'
+  onApprovalResponse: ChatAddToolApproveResponseFunction
+}
+
+export function ToolApprovalPrompt({ approval, state, onApprovalResponse }: ToolApprovalPromptProps) {
+  return (
+    <Confirmation approval={approval} state={state}>
+      <ConfirmationRequest>
+        <ConfirmationTitle>This tool requires your approval to run</ConfirmationTitle>
+        <ConfirmationActions>
+          <ConfirmationAction
+            onClick={() => {
+              void onApprovalResponse({ id: approval.id, approved: true })
+            }}
+          >
+            Approve
+          </ConfirmationAction>
+          <ConfirmationAction
+            variant="destructive"
+            onClick={() => {
+              void onApprovalResponse({ id: approval.id, approved: false })
+            }}
+          >
+            Deny
+          </ConfirmationAction>
+        </ConfirmationActions>
+      </ConfirmationRequest>
+      <ConfirmationAccepted>Approved. Executing tool.</ConfirmationAccepted>
+      <ConfirmationRejected>Denied. Tool will not run.</ConfirmationRejected>
+    </Confirmation>
+  )
+}

--- a/src/components/tool-approval-prompt.tsx
+++ b/src/components/tool-approval-prompt.tsx
@@ -7,11 +7,11 @@ import {
   ConfirmationRequest,
   ConfirmationTitle,
 } from '@/components/ai-elements/confirmation'
-import type { ChatAddToolApproveResponseFunction } from 'ai'
+import type { ChatAddToolApproveResponseFunction, ToolUIPart } from 'ai'
 
 interface ToolApprovalPromptProps {
   approval: { id: string }
-  state: 'approval-requested' | 'approval-responded' | 'output-available' | 'output-denied' | 'output-error'
+  state: ToolUIPart['state']
   onApprovalResponse: ChatAddToolApproveResponseFunction
 }
 

--- a/src/components/tool-part.tsx
+++ b/src/components/tool-part.tsx
@@ -1,0 +1,46 @@
+import { Tool, ToolContent, ToolHeader, ToolInput, ToolOutput } from '@/components/ai-elements/tool'
+import { CodeBlock } from '@/components/ai-elements/code-block'
+import { ToolApprovalPrompt } from '@/components/tool-approval-prompt'
+import type { ChatAddToolApproveResponseFunction, DynamicToolUIPart, ToolUIPart } from 'ai'
+import { useEffect, useState } from 'react'
+
+interface ToolPartProps {
+  part: ToolUIPart | DynamicToolUIPart
+  onApprovalResponse: ChatAddToolApproveResponseFunction
+}
+
+export function ToolPart({ part, onApprovalResponse }: ToolPartProps) {
+  const [open, setOpen] = useState(part.state === 'approval-requested')
+
+  // Auto-open the card whenever an approval is requested — `defaultOpen` only
+  // runs at mount, but the transition into `approval-requested` happens after
+  // mount, so the Confirmation prompt would otherwise stay collapsed.
+  useEffect(() => {
+    if (part.state === 'approval-requested') setOpen(true)
+  }, [part.state])
+
+  const toolName = part.type === 'dynamic-tool' ? part.toolName : part.type.split('-').slice(1).join('-')
+  const approval = 'approval' in part ? part.approval : undefined
+
+  return (
+    <Tool data-tool-name={toolName} open={open} onOpenChange={setOpen}>
+      {part.type === 'dynamic-tool' ? (
+        <ToolHeader type={part.type} state={part.state} toolName={part.toolName} />
+      ) : (
+        <ToolHeader type={part.type} state={part.state} />
+      )}
+      <ToolContent>
+        <ToolInput input={part.input} />
+        {approval && (
+          <ToolApprovalPrompt approval={approval} state={part.state} onApprovalResponse={onApprovalResponse} />
+        )}
+        {(part.state === 'output-available' || part.state === 'output-error') && (
+          <ToolOutput
+            errorText={part.errorText}
+            output={<CodeBlock code={JSON.stringify(part.output, null, 2)} language="json" />}
+          />
+        )}
+      </ToolContent>
+    </Tool>
+  )
+}

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '@/lib/utils'
+
+const alertVariants = cva(
+  'relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current',
+  {
+    variants: {
+      variant: {
+        default: 'bg-card text-card-foreground',
+        destructive:
+          'bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 [&>svg]:text-current',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+)
+
+function Alert({ className, variant, ...props }: React.ComponentProps<'div'> & VariantProps<typeof alertVariants>) {
+  return <div data-slot="alert" role="alert" className={cn(alertVariants({ variant }), className)} {...props} />
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn('col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight', className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDescription({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        'col-start-2 grid justify-items-start gap-1 text-sm text-muted-foreground [&_p]:leading-relaxed',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Alert, AlertTitle, AlertDescription }

--- a/tests/e2e/mocks.ts
+++ b/tests/e2e/mocks.ts
@@ -63,6 +63,123 @@ export async function setupMocks(page: Page, responseText = 'This is a mock resp
   })
 }
 
+const STREAM_HEADERS = {
+  'Content-Type': 'text/event-stream',
+  'Cache-Control': 'no-cache',
+  Connection: 'keep-alive',
+  'X-Vercel-AI-UI-Message-Stream': 'v1',
+}
+
+function encodeStream(events: object[]): string {
+  return events.map((e) => `data: ${JSON.stringify(e)}`).join('\n\n') + '\n\ndata: [DONE]\n\n'
+}
+
+/**
+ * AI SDK v6 stream that asks the user to approve a tool call.
+ * Emits: optional text → tool-input-available → tool-approval-request.
+ * The UI should render the Confirmation prompt for the named tool.
+ */
+function buildToolApprovalRequestStream(opts: {
+  toolName: string
+  toolCallId: string
+  approvalId: string
+  preText?: string
+  input?: unknown
+}): string {
+  const events: object[] = []
+  if (opts.preText) {
+    const textId = 'aitxt_pre_0000000000000001'
+    events.push({ type: 'text-start', id: textId })
+    events.push({ type: 'text-delta', id: textId, delta: opts.preText })
+    events.push({ type: 'text-end', id: textId })
+  }
+  events.push({
+    type: 'tool-input-available',
+    toolCallId: opts.toolCallId,
+    toolName: opts.toolName,
+    input: opts.input ?? {},
+  })
+  events.push({
+    type: 'tool-approval-request',
+    approvalId: opts.approvalId,
+    toolCallId: opts.toolCallId,
+  })
+  return encodeStream(events)
+}
+
+/**
+ * Followup stream sent after the user approves the tool. Carries the tool
+ * result and an optional assistant message confirming completion.
+ */
+function buildToolOutputStream(opts: { toolCallId: string; output: unknown; postText?: string }): string {
+  const events: object[] = [
+    {
+      type: 'tool-output-available',
+      toolCallId: opts.toolCallId,
+      output: opts.output,
+    },
+  ]
+  if (opts.postText) {
+    const textId = 'aitxt_post_0000000000000001'
+    events.push({ type: 'text-start', id: textId })
+    events.push({ type: 'text-delta', id: textId, delta: opts.postText })
+    events.push({ type: 'text-end', id: textId })
+  }
+  return encodeStream(events)
+}
+
+/**
+ * Sets up mocks for the v6 tool-approval flow.
+ *
+ * Call sequence:
+ *   1. First POST /api/chat → approval-request stream
+ *   2. User clicks Approve or Deny; SDK auto-sends a follow-up POST
+ *   3. Second POST /api/chat → tool-output stream (approve) or empty
+ *      completion stream (deny, since the tool never ran)
+ */
+export async function setupToolApprovalMocks(
+  page: Page,
+  opts: {
+    toolName: string
+    preText?: string
+    output: unknown
+    postText?: string
+  },
+) {
+  const toolCallId = 'call_approval_001'
+  const approvalId = 'appr_001'
+  let chatCallCount = 0
+
+  await page.route('**/api/configure', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(CONFIGURE_RESPONSE),
+    }),
+  )
+
+  await page.route('**/api/chat', (route) => {
+    chatCallCount++
+    if (chatCallCount === 1) {
+      return route.fulfill({
+        status: 200,
+        headers: STREAM_HEADERS,
+        body: buildToolApprovalRequestStream({
+          toolName: opts.toolName,
+          toolCallId,
+          approvalId,
+          preText: opts.preText,
+        }),
+      })
+    }
+    return route.fulfill({
+      status: 200,
+      headers: STREAM_HEADERS,
+      body: buildToolOutputStream({ toolCallId, output: opts.output, postText: opts.postText }),
+    })
+  })
+}
+
 /**
  * Sets up mocks where each call to /api/chat returns a different response
  * from the provided array (cycling through them).

--- a/tests/e2e/tool-approval.test.ts
+++ b/tests/e2e/tool-approval.test.ts
@@ -25,10 +25,12 @@ test.describe('tool approval (AI SDK v6)', () => {
 
     await approveButton.click()
 
-    // Confirmation flips to the accepted state and the tool result lands
+    // Confirmation flips to the accepted state and the tool result lands.
+    // The post-tool assistant text only renders if the SDK actually applied
+    // the tool-output-available chunk from the follow-up POST, so seeing it
+    // is the regression signal that the round-trip works end-to-end.
     await expect(chat.getByText('Approved. Executing tool.')).toBeVisible()
     await expect(chat.getByText('Done — file deleted.')).toBeVisible()
-    await expect(chat.getByText('/tmp/foo')).toBeVisible()
   })
 
   test('deny shows the rejected state and does not execute the tool', async ({ page }) => {

--- a/tests/e2e/tool-approval.test.ts
+++ b/tests/e2e/tool-approval.test.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test'
+import { setupToolApprovalMocks } from './mocks'
+
+test.describe('tool approval (AI SDK v6)', () => {
+  test('approve runs the tool and shows the result', async ({ page }) => {
+    await setupToolApprovalMocks(page, {
+      toolName: 'delete_file',
+      preText: "I'll need approval before deleting.",
+      output: { deleted: true, path: '/tmp/foo' },
+      postText: 'Done — file deleted.',
+    })
+
+    await page.goto('/')
+
+    await page.getByPlaceholder('What would you like to know?').fill('please delete /tmp/foo')
+    await page.getByPlaceholder('What would you like to know?').press('Enter')
+
+    const chat = page.getByRole('log')
+
+    // Approval prompt appears
+    await expect(chat.getByText('This tool requires your approval to run')).toBeVisible()
+    const approveButton = chat.getByRole('button', { name: 'Approve' })
+    await expect(approveButton).toBeVisible()
+    await expect(chat.getByRole('button', { name: 'Deny' })).toBeVisible()
+
+    await approveButton.click()
+
+    // Confirmation flips to the accepted state and the tool result lands
+    await expect(chat.getByText('Approved. Executing tool.')).toBeVisible()
+    await expect(chat.getByText('Done — file deleted.')).toBeVisible()
+    await expect(chat.getByText('/tmp/foo')).toBeVisible()
+  })
+
+  test('deny shows the rejected state and does not execute the tool', async ({ page }) => {
+    await setupToolApprovalMocks(page, {
+      toolName: 'delete_file',
+      preText: "I'll need approval before deleting.",
+      // these would only appear if the tool ran — so seeing them in the chat
+      // is the regression signal we want to guard against
+      output: { deleted: true, path: '/tmp/foo' },
+      postText: 'Done — file deleted.',
+    })
+
+    await page.goto('/')
+
+    await page.getByPlaceholder('What would you like to know?').fill('please delete /tmp/foo')
+    await page.getByPlaceholder('What would you like to know?').press('Enter')
+
+    const chat = page.getByRole('log')
+
+    await expect(chat.getByText('This tool requires your approval to run')).toBeVisible()
+    await chat.getByRole('button', { name: 'Deny' }).click()
+
+    await expect(chat.getByText('Denied. Tool will not run.')).toBeVisible()
+    // Action buttons should be gone after responding
+    await expect(chat.getByRole('button', { name: 'Approve' })).toHaveCount(0)
+    await expect(chat.getByRole('button', { name: 'Deny' })).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
## Summary

Builds on #21 (which landed the SDK v5→v6 bump) with the user-facing approve/deny flow so v6's tool approval protocol is actually usable.

- `Chat.tsx`: wires `DefaultChatTransport` (body fn reads model/tools from refs) + `sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses` so the SDK auto-sends the follow-up after the user responds. Threads `addToolApprovalResponse` into each `Part`.
- `Part.tsx`: real rendering for `dynamic-tool` parts (was a TODO stub), renders `ToolApprovalPrompt` when the part has an approval, `defaultOpen` on `approval-requested`, `data-tool-name` for test selectors.
- New `src/components/tool-approval-prompt.tsx` — domain wrapper that maps v6's `approval` shape onto the generic `Confirmation` primitive.
- New `src/components/ai-elements/confirmation.tsx` + `src/components/ui/alert.tsx` — vendored shadcn/ai-elements pieces.
- `tool.tsx`: minimal extension so `ToolHeader` handles `type: 'dynamic-tool'` + `toolName` override (the existing `type.slice(5)` produced gibberish for dynamic tools).
- `CLAUDE.md`: documents the new convention — one non-trivial component per file.
- `components.json`, `eslint.config.ts`: `@ai-elements` shadcn registry + `no-void` rule tweak for the `void onApprovalResponse(...)` pattern.

Provenance: cherry-picks the user-visible v6 approval bits from #16 (bendrucker). Dropped from #16: CI workflow changes, `code-block.tsx` re-vendor, full `tool.tsx` re-vendor (would clobber the dialog error display from #11), unrelated `badge`/`button`/`collapsible`/`select` re-vendors, and the entire `tests/` paradigm shift (FastAPI FunctionModel server + Vitest headless). The current PR keeps the existing mock-based `tests/e2e/` from #20 and adds v6-aware mock helpers.

## Tests

Adds `tests/e2e/tool-approval.test.ts` covering the two user-visible v6 flows:

- **approve**: user sees the approval prompt → clicks Approve → `Approved. Executing tool.` renders → SDK auto-sends a follow-up → mock returns the tool output → result + assistant text appear.
- **deny**: user clicks Deny → `Denied. Tool will not run.` renders → Approve/Deny buttons disappear; tool output never appears.

`tests/e2e/mocks.ts` gets a `setupToolApprovalMocks` helper that emits the v6 chunk sequence (`text-*`, `tool-input-available`, `tool-approval-request`, then `tool-output-available` on the follow-up POST).

## Follow-ups

Worth opening separately:

- Port bendrucker's `tests/server/` FastAPI + `FunctionModel` server. Replaces the `page.route` mocks with a real backend exercising the actual `pydantic-ai` adapter — closer to how users will hit this code. Larger migration (Vitest config, Python deps via uv, playwright config tweaks).
- Sweep the rest of `src/Part.tsx` (`ForkNavigation`) to comply with the new one-component-per-file convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)