### PR TITLE
Replace the effort "Default" option with an explicit Medium default

### DIFF
--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -59,7 +59,11 @@ async function getModels() {
 const Chat = () => {
   const [input, setInput] = useState('')
   const [model, setModel] = useState('')
-  const [effort, setEffort] = useState<string>(() => localStorage.getItem('effort') ?? '')
+  const [effort, setEffort] = useState<string>(() => {
+    const stored = localStorage.getItem('effort')
+    // Empty string was the old "Default" sentinel; migrate it to an explicit level.
+    return stored && stored !== '' ? stored : 'medium'
+  })
   const [enabledTools, setEnabledTools] = useState<string[]>([])
   const modelRef = useRef(model)
   modelRef.current = model

--- a/src/components/effort-select.tsx
+++ b/src/components/effort-select.tsx
@@ -25,7 +25,6 @@ const EFFORT_LABELS: Record<ThinkingEffort, string> = {
 }
 
 const EFFORT_OPTIONS: EffortOption[] = [
-  { label: 'Effort: Default', selectValue: 'default' },
   ...THINKING_EFFORT_LEVELS.map((level) => ({
     label: `Effort: ${EFFORT_LABELS[level]}`,
     selectValue: level,
@@ -38,15 +37,8 @@ interface EffortSelectProps {
 }
 
 export const EffortSelect = ({ value, onValueChange }: EffortSelectProps) => {
-  const selectValue = value === '' ? 'default' : value
-
   return (
-    <PromptInputModelSelect
-      value={selectValue}
-      onValueChange={(v) => {
-        onValueChange(v === 'default' ? '' : v)
-      }}
-    >
+    <PromptInputModelSelect value={value} onValueChange={onValueChange}>
       <PromptInputModelSelectTrigger>
         <PromptInputModelSelectValue />
       </PromptInputModelSelectTrigger>

--- a/tests/e2e/deterministic/effort-select.spec.ts
+++ b/tests/e2e/deterministic/effort-select.spec.ts
@@ -8,7 +8,6 @@ test.describe('effort selector', () => {
       .getByRole('combobox')
       .filter({ hasText: /^Effort:/ })
       .click()
-    await expect(page.getByRole('option', { name: 'Effort: Default' })).toBeVisible()
     await expect(page.getByRole('option', { name: 'Effort: Minimal' })).toBeVisible()
     await expect(page.getByRole('option', { name: 'Effort: Low' })).toBeVisible()
     await expect(page.getByRole('option', { name: 'Effort: Medium' })).toBeVisible()
@@ -36,7 +35,7 @@ test.describe('effort selector', () => {
     await expect(page.getByText('Hello from the test server')).toBeVisible()
   })
 
-  test('default effort sends empty string in the request body', async ({ page }) => {
+  test('default effort is medium and is sent in the request body', async ({ page }) => {
     await page.goto('/')
 
     const requestPromise = page.waitForRequest('**/api/chat')
@@ -44,7 +43,7 @@ test.describe('effort selector', () => {
     const request = await requestPromise
 
     const body = request.postDataJSON() as Record<string, unknown>
-    expect(body.effort).toBe('')
+    expect(body.effort).toBe('medium')
     expect(body.model).toBeTruthy()
 
     await expect(page.getByText('Hello from the test server')).toBeVisible()


### PR DESCRIPTION
David's AICA here:

The reasoning-effort dropdown (added in #28) led with an "Effort: Default" option that mapped to an empty string (no override). In practice users can't tell what reasoning level "Default" actually produces, so it reads as confusing.

This drops the "Default" option and the empty-string sentinel it required. The dropdown now offers the five concrete `ThinkingEffort` levels and **defaults to Medium**; `Chat.tsx` migrates any previously stored empty value to `medium`. The deterministic E2E spec is updated (default now sends `medium`, and the "Default" option assertion is removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)