### PR TITLE
Add tool-call filters: hide noisy tools by name or glob

### DIFF
--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -16,15 +16,18 @@ import {
 import { Source, Sources, SourcesContent, SourcesTrigger } from '@/components/ai-elements/sources'
 import { EffortSelect } from '@/components/effort-select'
 import { EditMessageDialog } from '@/components/edit-message-dialog'
+import { HiddenToolsGroup } from '@/components/hidden-tools-group'
+import { ToolFiltersDialog } from '@/components/tool-filters-dialog'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { Switch } from '@/components/ui/switch'
+import { ToolFiltersProvider, useToolFilters } from '@/contexts/tool-filters'
 import { useChat } from '@ai-sdk/react'
 import { DefaultChatTransport, lastAssistantMessageIsCompleteWithApprovalResponses } from 'ai'
-import type { UIDataTypes, UIMessagePart, UITools } from 'ai'
-import { ArrowRightIcon, RefreshCcwIcon, Settings2Icon } from 'lucide-react'
+import type { UIDataTypes, UIMessage, UIMessagePart, UITools } from 'ai'
+import { ArrowRightIcon, FilterIcon, RefreshCcwIcon, Settings2Icon } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { useCallback, useEffect, useMemo, useRef, useState, type SyntheticEvent } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode, type SyntheticEvent } from 'react'
 
 import { useQuery } from '@tanstack/react-query'
 import { useThrottle } from '@uidotdev/usehooks'
@@ -33,6 +36,7 @@ import { useConversationIdFromUrl } from './hooks/useConversationIdFromUrl'
 import { Part } from './Part'
 import type { ConversationEntry } from './types'
 import { getToolIcon } from '@/lib/tool-icons'
+import { toolNameOfPart } from '@/lib/tool-filters'
 import { getMessages, saveMessages, saveConversation } from '@/lib/chat-db'
 import { stripBasePath, withBasePath } from '@/lib/base-path'
 
@@ -58,7 +62,9 @@ async function getModels() {
   return (await res.json()) as RemoteConfig
 }
 
-const Chat = () => {
+const ChatInner = () => {
+  const { isFiltered } = useToolFilters()
+  const [filtersDialogOpen, setFiltersDialogOpen] = useState(false)
   const [input, setInput] = useState('')
   const [model, setModel] = useState('')
   const [effort, setEffort] = useState<string>(() => {
@@ -321,26 +327,30 @@ const Chat = () => {
                       ))}
                   </Sources>
                 )}
-              {message.parts.map((part, i) => (
-                <Part
-                  key={`${message.id}-${i}`}
-                  part={part}
-                  message={message}
-                  status={status}
-                  index={i}
-                  regen={regen}
-                  lastMessage={message.id === messages.at(-1)?.id}
-                  onApprovalResponse={addToolApprovalResponse}
-                  isEditing={editingMessageId === message.id}
-                  editDraft={editDraftsRef.current.get(message.id)}
-                  onStartEdit={handleStartEdit}
-                  onCancelEdit={handleCancelEdit}
-                  onSubmitEdit={handleSubmitEdit}
-                  conversationId={conversationId}
-                  messageIndex={messageIndex}
-                  onNavigateToFork={handleNavigateToFork}
-                />
-              ))}
+              {renderMessageParts(
+                message,
+                (part, i) => (
+                  <Part
+                    key={`${message.id}-${i}`}
+                    part={part}
+                    message={message}
+                    status={status}
+                    index={i}
+                    regen={regen}
+                    lastMessage={message.id === messages.at(-1)?.id}
+                    onApprovalResponse={addToolApprovalResponse}
+                    isEditing={editingMessageId === message.id}
+                    editDraft={editDraftsRef.current.get(message.id)}
+                    onStartEdit={handleStartEdit}
+                    onCancelEdit={handleCancelEdit}
+                    onSubmitEdit={handleSubmitEdit}
+                    conversationId={conversationId}
+                    messageIndex={messageIndex}
+                    onNavigateToFork={handleNavigateToFork}
+                  />
+                ),
+                isFiltered,
+              )}
             </div>
           ))}
           {status === 'submitted' && <Loader />}
@@ -377,6 +387,20 @@ const Chat = () => {
           />
           <PromptInputToolbar>
             <PromptInputTools>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <PromptInputButton
+                    variant="outline"
+                    aria-label="Hidden tools"
+                    onClick={() => {
+                      setFiltersDialogOpen(true)
+                    }}
+                  >
+                    <FilterIcon className="size-4" />
+                  </PromptInputButton>
+                </TooltipTrigger>
+                <TooltipContent>Hidden tools</TooltipContent>
+              </Tooltip>
               {availableTools.length > 0 && (
                 <DropdownMenu>
                   <Tooltip>
@@ -460,11 +484,57 @@ const Chat = () => {
         onModify={handleModify}
         onFork={handleFork}
       />
+
+      <ToolFiltersDialog open={filtersDialogOpen} onOpenChange={setFiltersDialogOpen} />
     </>
   )
 }
 
+const Chat = () => (
+  // Upstream default is an empty filter list. A host (e.g. loopy) seeds its own
+  // noisy tool names by passing `defaults={[...]}` here.
+  <ToolFiltersProvider defaults={[]}>
+    <ChatInner />
+  </ToolFiltersProvider>
+)
+
 export default Chat
+
+// Walk a message's parts and render them, collapsing runs of consecutive
+// filtered tool parts into a single `HiddenToolsGroup`. `renderPart` is the
+// per-part renderer (returns a `<Part>` element); grouping is message-level so
+// it lives here rather than in `Part`. Non-filtered parts render unchanged.
+function renderMessageParts(
+  message: UIMessage,
+  renderPart: (part: UIMessagePart<UIDataTypes, UITools>, index: number) => ReactNode,
+  isFiltered: (toolName: string) => boolean,
+): ReactNode[] {
+  const out: ReactNode[] = []
+  let run: { node: ReactNode; toolName: string }[] = []
+
+  const flush = () => {
+    if (run.length === 0) return
+    out.push(
+      <HiddenToolsGroup key={`hidden-${message.id}-${out.length}`} toolNames={run.map((entry) => entry.toolName)}>
+        {run.map((entry) => entry.node)}
+      </HiddenToolsGroup>,
+    )
+    run = []
+  }
+
+  message.parts.forEach((part, i) => {
+    const toolName = toolNameOfPart(part)
+    if (toolName !== null && isFiltered(toolName)) {
+      run.push({ node: renderPart(part, i), toolName })
+    } else {
+      flush()
+      out.push(renderPart(part, i))
+    }
+  })
+  flush()
+
+  return out
+}
 
 // A tool part whose state is not one of these has no output (or denial) yet, so
 // continuing would leave the backend with an orphaned tool call.

--- a/src/components/hidden-tools-group.tsx
+++ b/src/components/hidden-tools-group.tsx
@@ -1,0 +1,53 @@
+import { EyeIcon, EyeOffIcon } from 'lucide-react'
+import { useState, type ReactNode } from 'react'
+
+interface HiddenToolsGroupProps {
+  toolNames: string[]
+  children: ReactNode
+}
+
+/**
+ * Collapse a run of consecutive filtered tool parts into a single muted line.
+ * Collapsed, it shows "N tools hidden" with a show toggle; expanded, it reveals
+ * the real tool cards (`children`) inline plus a hide toggle.
+ */
+export function HiddenToolsGroup({ toolNames, children }: HiddenToolsGroupProps) {
+  const [expanded, setExpanded] = useState(false)
+  const count = toolNames.length
+  const label = `${count} tool${count === 1 ? '' : 's'} hidden`
+
+  if (!expanded) {
+    return (
+      <button
+        type="button"
+        data-slot="hidden-tools-group"
+        title={toolNames.join(', ')}
+        onClick={() => {
+          setExpanded(true)
+        }}
+        className="my-2 flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <EyeOffIcon className="size-3.5" />
+        <span>{label}</span>
+        <span className="underline underline-offset-2">show</span>
+      </button>
+    )
+  }
+
+  return (
+    <div data-slot="hidden-tools-group" className="my-2">
+      <button
+        type="button"
+        onClick={() => {
+          setExpanded(false)
+        }}
+        className="mb-1 flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <EyeIcon className="size-3.5" />
+        <span>{label}</span>
+        <span className="underline underline-offset-2">hide</span>
+      </button>
+      {children}
+    </div>
+  )
+}

--- a/src/components/tool-filters-dialog.tsx
+++ b/src/components/tool-filters-dialog.tsx
@@ -1,0 +1,69 @@
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { useToolFilters } from '@/contexts/tool-filters'
+import { XIcon } from 'lucide-react'
+import { useState, type SyntheticEvent } from 'react'
+
+interface ToolFiltersDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function ToolFiltersDialog({ open, onOpenChange }: ToolFiltersDialogProps) {
+  const { filters, addFilter, removeFilter } = useToolFilters()
+  const [draft, setDraft] = useState('')
+
+  const submit = (e: SyntheticEvent) => {
+    e.preventDefault()
+    addFilter(draft)
+    setDraft('')
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Hidden tools</DialogTitle>
+          <DialogDescription>Hide tool-call cards by name or glob, e.g. set_* or run_code</DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-2">
+          {filters.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No filters yet. Add a tool name or glob below.</p>
+          ) : (
+            filters.map((filter) => (
+              <div key={filter} className="flex items-center justify-between gap-2 rounded-md border px-3 py-1.5">
+                <span className="font-mono text-sm">{filter}</span>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="size-6"
+                  aria-label={`Remove ${filter}`}
+                  onClick={() => {
+                    removeFilter(filter)
+                  }}
+                >
+                  <XIcon className="size-4" />
+                </Button>
+              </div>
+            ))
+          )}
+        </div>
+
+        <form className="flex items-center gap-2" onSubmit={submit}>
+          <Input
+            value={draft}
+            placeholder="Tool name or glob (e.g. set_*)"
+            onChange={(e) => {
+              setDraft(e.target.value)
+            }}
+          />
+          <Button type="submit" disabled={draft.trim() === ''}>
+            Add
+          </Button>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/tool-part.tsx
+++ b/src/components/tool-part.tsx
@@ -3,7 +3,9 @@ import { ToolApprovalPrompt } from '@/components/tool-approval-prompt'
 import { ToolOutputCode } from '@/components/tool-output-code'
 import { RunCodeInput } from '@/components/run-code-input'
 import { isRunCodeOutput, RunCodeOutput } from '@/components/run-code-output'
+import { useToolFilters } from '@/contexts/tool-filters'
 import type { ChatAddToolApproveResponseFunction, DynamicToolUIPart, ToolUIPart } from 'ai'
+import { EyeOffIcon } from 'lucide-react'
 import { useEffect, useState } from 'react'
 
 interface ToolPartProps {
@@ -14,6 +16,7 @@ interface ToolPartProps {
 export function ToolPart({ part, onApprovalResponse }: ToolPartProps) {
   const approval = 'approval' in part ? part.approval : undefined
   const [open, setOpen] = useState(() => part.state === 'approval-requested' || Boolean(approval))
+  const { addFilter } = useToolFilters()
 
   // Auto-open the card whenever an approval is requested — `defaultOpen` only
   // runs at mount, but the transition into `approval-requested` happens after
@@ -26,7 +29,18 @@ export function ToolPart({ part, onApprovalResponse }: ToolPartProps) {
   const isRunCode = toolName === 'run_code'
 
   return (
-    <Tool data-tool-name={toolName} open={open} onOpenChange={setOpen}>
+    <Tool data-tool-name={toolName} open={open} onOpenChange={setOpen} className="group/tool-part relative">
+      <button
+        type="button"
+        aria-label="Hide this tool"
+        title={`Hide ${toolName} tool cards`}
+        onClick={() => {
+          addFilter(toolName)
+        }}
+        className="absolute top-2.5 right-9 z-10 rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover/tool-part:opacity-100"
+      >
+        <EyeOffIcon className="size-3.5" />
+      </button>
       {part.type === 'dynamic-tool' ? (
         <ToolHeader type={part.type} state={part.state} toolName={part.toolName} />
       ) : (

--- a/src/contexts/tool-filters.tsx
+++ b/src/contexts/tool-filters.tsx
@@ -1,0 +1,63 @@
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react'
+import { isToolFiltered, loadFilters, saveFilters } from '@/lib/tool-filters'
+
+interface ToolFiltersValue {
+  filters: string[]
+  addFilter: (filter: string) => void
+  removeFilter: (filter: string) => void
+  isFiltered: (toolName: string) => boolean
+}
+
+const ToolFiltersContext = createContext<ToolFiltersValue | null>(null)
+
+interface ToolFiltersProviderProps {
+  children: ReactNode
+  /**
+   * Tool-name filters (exact names or globs like `set_*`) seeded on first load,
+   * before the user has saved any list of their own. Empty upstream; a host
+   * (e.g. loopy) passes its noisy tool names here to hide them by default.
+   */
+  defaults?: string[]
+}
+
+export function ToolFiltersProvider({ children, defaults = [] }: ToolFiltersProviderProps) {
+  const [filters, setFilters] = useState<string[]>(() => loadFilters(defaults))
+
+  const persist = useCallback((next: string[]) => {
+    setFilters(next)
+    saveFilters(next)
+  }, [])
+
+  const addFilter = useCallback(
+    (filter: string) => {
+      const trimmed = filter.trim()
+      if (trimmed === '' || filters.includes(trimmed)) return
+      persist([...filters, trimmed])
+    },
+    [filters, persist],
+  )
+
+  const removeFilter = useCallback(
+    (filter: string) => {
+      persist(filters.filter((entry) => entry !== filter))
+    },
+    [filters, persist],
+  )
+
+  const isFiltered = useCallback((toolName: string) => isToolFiltered(toolName, filters), [filters])
+
+  const value = useMemo<ToolFiltersValue>(
+    () => ({ filters, addFilter, removeFilter, isFiltered }),
+    [filters, addFilter, removeFilter, isFiltered],
+  )
+
+  return <ToolFiltersContext.Provider value={value}>{children}</ToolFiltersContext.Provider>
+}
+
+export function useToolFilters(): ToolFiltersValue {
+  const value = useContext(ToolFiltersContext)
+  if (value === null) {
+    throw new Error('useToolFilters must be used within a ToolFiltersProvider')
+  }
+  return value
+}

--- a/src/lib/tool-filters.ts
+++ b/src/lib/tool-filters.ts
@@ -1,0 +1,74 @@
+const STORAGE_KEY = 'toolFilters'
+
+/**
+ * The minimal shape needed to identify a tool part and read its name. A real
+ * `UIMessagePart` satisfies this; typing it structurally keeps the function
+ * usable with test fixtures without widening to `any`.
+ */
+interface PartLike {
+  type: string
+  toolName?: string
+  toolCallId?: string
+}
+
+/**
+ * Return the tool name if `part` is a tool part, else `null`.
+ *
+ * Mirrors the tool-part detection in `Part.tsx` and the name extraction in
+ * `tool-part.tsx`: a part is a tool part iff it is a `dynamic-tool` part or
+ * carries a `toolCallId`. A static tool part's `type` is `tool-<name>`.
+ */
+export function toolNameOfPart(part: PartLike): string | null {
+  if (part.type === 'dynamic-tool') return part.toolName ?? null
+  if ('toolCallId' in part) return part.type.split('-').slice(1).join('-')
+  return null
+}
+
+function globToRegExp(glob: string): RegExp {
+  const escaped = glob.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\\\*/g, '.*')
+  return new RegExp(`^${escaped}$`)
+}
+
+/**
+ * Match `toolName` against a single `filter`. A filter containing `*` is a glob
+ * (case-sensitive, anchored); otherwise it is an exact string match. A blank
+ * filter matches nothing.
+ */
+export function filterMatches(toolName: string, filter: string): boolean {
+  if (filter === '') return false
+  if (filter.includes('*')) return globToRegExp(filter).test(toolName)
+  return toolName === filter
+}
+
+/** True if any filter in `filters` matches `toolName`. */
+export function isToolFiltered(toolName: string, filters: string[]): boolean {
+  return filters.some((filter) => filterMatches(toolName, filter))
+}
+
+/**
+ * Load filters from localStorage. Returns the stored list if a value exists
+ * (even an empty list, so a user who cleared their filters keeps an empty list),
+ * else `defaults`. Defaults therefore seed only on first load.
+ */
+export function loadFilters(defaults: string[]): string[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (raw === null) return defaults
+    const parsed: unknown = JSON.parse(raw)
+    if (Array.isArray(parsed) && parsed.every((entry) => typeof entry === 'string')) {
+      return parsed
+    }
+    return defaults
+  } catch {
+    return defaults
+  }
+}
+
+/** Persist `filters` to localStorage as a JSON string array. */
+export function saveFilters(filters: string[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(filters))
+  } catch {
+    // Ignore write failures (e.g. storage disabled); filters stay in memory.
+  }
+}

--- a/tests/e2e/deterministic/tool-filters.spec.ts
+++ b/tests/e2e/deterministic/tool-filters.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test'
+import { sendMessage } from '../conversation'
+import { toolCard } from '../tools'
+
+test.describe('tool filters', () => {
+  test('hides a tool by name and reveals it inline', async ({ page }) => {
+    await page.goto('/')
+    await sendMessage(page, 'tool', 'What is the weather?')
+
+    const card = toolCard(page, 'get_weather')
+    await expect(card).toBeVisible()
+
+    // Open the filter dialog and add a filter for get_weather.
+    await page.getByRole('button', { name: 'Hidden tools' }).click()
+    const dialog = page.getByRole('dialog')
+    await dialog.getByPlaceholder('Tool name or glob (e.g. set_*)').fill('get_weather')
+    await dialog.getByRole('button', { name: 'Add', exact: true }).click()
+
+    // Close the dialog (Escape) and assert the card collapsed into the hidden line.
+    await page.keyboard.press('Escape')
+    await expect(card).toBeHidden()
+    const hiddenLine = page.getByText('1 tool hidden')
+    await expect(hiddenLine).toBeVisible()
+
+    // Reveal inline.
+    await page.getByRole('button', { name: /1 tool hidden/ }).click()
+    await expect(card).toBeVisible()
+  })
+})

--- a/tests/headless/tool-filters.test.ts
+++ b/tests/headless/tool-filters.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import { filterMatches, isToolFiltered, toolNameOfPart } from '../../src/lib/tool-filters'
+
+describe('filterMatches', () => {
+  it('matches exact names', () => {
+    expect(filterMatches('get_weather', 'get_weather')).toBe(true)
+    expect(filterMatches('get_weather', 'calculate')).toBe(false)
+  })
+
+  it('does not partial-match without a glob', () => {
+    expect(filterMatches('get_weather', 'weather')).toBe(false)
+    expect(filterMatches('get_weather', 'get_')).toBe(false)
+  })
+
+  it('glob set_* matches set_goal but not goal_set', () => {
+    expect(filterMatches('set_goal', 'set_*')).toBe(true)
+    expect(filterMatches('set_status', 'set_*')).toBe(true)
+    expect(filterMatches('goal_set', 'set_*')).toBe(false)
+  })
+
+  it('lone * matches anything non-empty and empty', () => {
+    expect(filterMatches('anything', '*')).toBe(true)
+    expect(filterMatches('', '*')).toBe(true)
+  })
+
+  it('glob is anchored at both ends', () => {
+    expect(filterMatches('run_code', '*code')).toBe(true)
+    expect(filterMatches('run_code', 'run*')).toBe(true)
+    expect(filterMatches('run_code_2', 'run*code')).toBe(false)
+    expect(filterMatches('run_x_code', 'run*code')).toBe(true)
+  })
+
+  it('escapes regex special chars outside the glob star', () => {
+    expect(filterMatches('a.b', 'a.b')).toBe(true)
+    expect(filterMatches('axb', 'a.b')).toBe(false)
+    expect(filterMatches('a.b', 'a.*')).toBe(true)
+    expect(filterMatches('axb', 'a.*')).toBe(false)
+  })
+
+  it('a blank filter matches nothing', () => {
+    expect(filterMatches('get_weather', '')).toBe(false)
+    expect(filterMatches('', '')).toBe(false)
+  })
+
+  it('glob is case-sensitive', () => {
+    expect(filterMatches('Set_goal', 'set_*')).toBe(false)
+  })
+})
+
+describe('isToolFiltered', () => {
+  it('is true when any filter matches', () => {
+    expect(isToolFiltered('set_goal', ['run_code', 'set_*'])).toBe(true)
+    expect(isToolFiltered('get_weather', ['get_weather'])).toBe(true)
+  })
+
+  it('is false when no filter matches', () => {
+    expect(isToolFiltered('get_weather', ['set_*', 'run_code'])).toBe(false)
+    expect(isToolFiltered('get_weather', [])).toBe(false)
+  })
+})
+
+describe('toolNameOfPart', () => {
+  it('returns the name for a static tool part (tool-<name>)', () => {
+    expect(toolNameOfPart({ type: 'tool-get_weather', toolCallId: 'call-1' })).toBe('get_weather')
+  })
+
+  it('joins hyphenated static tool names after the tool- prefix', () => {
+    expect(toolNameOfPart({ type: 'tool-multi-word-name', toolCallId: 'call-1' })).toBe('multi-word-name')
+  })
+
+  it('returns the toolName for a dynamic-tool part', () => {
+    expect(toolNameOfPart({ type: 'dynamic-tool', toolName: 'run_code', toolCallId: 'call-2' })).toBe('run_code')
+  })
+
+  it('returns null for a non-tool part', () => {
+    expect(toolNameOfPart({ type: 'text' })).toBe(null)
+    expect(toolNameOfPart({ type: 'reasoning' })).toBe(null)
+  })
+})


### PR DESCRIPTION
David's AICA here.

## What

Lets the user hide noisy tool-call cards in the chat by tool name or glob pattern.

- A toolbar dialog manages the filter list (add by exact name like `run_code` or glob like `set_*`; remove individually). Each tool card also has a quick "hide this tool" action.
- Consecutive filtered tool parts collapse into a subtle per-message line ("N tools hidden -- show") that expands inline to reveal the real cards. Nothing is lost.
- Filters persist in `localStorage`.

## General by design

The default filter list is empty. A host application seeds its own noisy tool names by passing `defaults` to `ToolFiltersProvider` (documented inline in `Chat.tsx`). No app-specific tool names are hardcoded.

## How

`src/lib/tool-filters.ts` holds the pure logic (tool-name extraction, glob/exact matching, persistence). A `ToolFiltersContext` owns the filter state so the deep "hide this tool" action avoids prop-drilling. Grouping happens at the message-parts map in `Chat.tsx` (`renderMessageParts`), wrapping runs of filtered tool parts in `HiddenToolsGroup`; `Part` stays the sole renderer.

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm build`, `pnpm test:headless` (incl. new unit tests for the matching logic), and a new e2e (`tool-filters.spec.ts`: add a filter, assert collapse, expand, assert reveal) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)