### PR TITLE
fix: memo the CodeBlock usages to run highlighting only once

### DIFF
--- a/src/components/run-code-input.tsx
+++ b/src/components/run-code-input.tsx
@@ -1,6 +1,10 @@
 import { CodeBlock, CodeBlockCopyButton } from '@/components/ai-elements/code-block'
 import { Badge } from '@/components/ui/badge'
 import type { ToolPart } from '@/components/ai-elements/tool'
+import { memo } from 'react'
+
+// Memoize to avoid re-running highlighters on unchanged code.
+const CodeBlockMemo = memo(CodeBlock, (prev, next) => prev.code === next.code)
 
 interface RunCodeInputProps {
   input: ToolPart['input']
@@ -27,9 +31,9 @@ export function RunCodeInput({ input }: RunCodeInputProps) {
         )}
       </div>
       <div className="rounded-md bg-muted/50">
-        <CodeBlock code={code} language="python" showLineNumbers>
+        <CodeBlockMemo code={code} language="python" showLineNumbers>
           <CodeBlockCopyButton />
-        </CodeBlock>
+        </CodeBlockMemo>
       </div>
     </div>
   )

--- a/src/components/run-code-output.tsx
+++ b/src/components/run-code-output.tsx
@@ -1,4 +1,4 @@
-import { CodeBlock } from '@/components/ai-elements/code-block'
+import { ToolOutputCode } from '@/components/tool-output-code'
 import type { ToolPart } from '@/components/ai-elements/tool'
 
 export interface RunCodeResult {
@@ -32,7 +32,7 @@ export function RunCodeOutput({ output }: RunCodeOutputProps) {
         <div className="space-y-2">
           <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">Result</h4>
           <div className="rounded-md bg-muted/50">
-            <CodeBlock code={JSON.stringify(output.result, null, 2)} language="json" />
+            <ToolOutputCode output={output.result} />
           </div>
         </div>
       )}

--- a/src/components/tool-output-code.tsx
+++ b/src/components/tool-output-code.tsx
@@ -1,8 +1,11 @@
 import { CodeBlock } from '@/components/ai-elements/code-block'
-import { useMemo } from 'react'
+import { memo, useMemo } from 'react'
 
 // Avoid running two Prism highlighters over very large tool payloads.
 const LARGE_TOOL_OUTPUT_LENGTH = 20_000
+
+// Memoize to avoid re-running highlighters on unchanged code.
+const CodeBlockMemo = memo(CodeBlock)
 
 function stringifyToolOutput(output: unknown): string {
   try {
@@ -20,5 +23,5 @@ export function ToolOutputCode({ output }: { output: unknown }) {
     return <pre className="max-h-96 overflow-auto p-4 font-mono text-xs whitespace-pre-wrap break-words">{code}</pre>
   }
 
-  return <CodeBlock code={code} language="json" />
+  return <CodeBlockMemo code={code} language="json" />
 }

--- a/src/components/tool-part.tsx
+++ b/src/components/tool-part.tsx
@@ -4,7 +4,10 @@ import { ToolOutputCode } from '@/components/tool-output-code'
 import { RunCodeInput } from '@/components/run-code-input'
 import { isRunCodeOutput, RunCodeOutput } from '@/components/run-code-output'
 import type { ChatAddToolApproveResponseFunction, DynamicToolUIPart, ToolUIPart } from 'ai'
-import { useEffect, useState } from 'react'
+import { memo, useEffect, useState } from 'react'
+
+// Memoize to avoid re-running highlighters on unchanged code.
+const ToolInputMemo = memo(ToolInput)
 
 interface ToolPartProps {
   part: ToolUIPart | DynamicToolUIPart
@@ -35,7 +38,7 @@ export function ToolPart({ part, onApprovalResponse }: ToolPartProps) {
       <ToolContent>
         {open && (
           <>
-            {isRunCode ? <RunCodeInput input={part.input} /> : <ToolInput input={part.input} />}
+            {isRunCode ? <RunCodeInput input={part.input} /> : <ToolInputMemo input={part.input} />}
             {approval && (
               <ToolApprovalPrompt approval={approval} state={part.state} onApprovalResponse={onApprovalResponse} />
             )}


### PR DESCRIPTION
Otherwise highlighting is run every time react re-render, freezing the page when a tool output is opened.

Also make run-code-ouput use the tool-output-code component.

Related to #9