### PR TITLE
fix: make sidebar reachable on mobile and use dynamic viewport units

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import Chat from './Chat.tsx'
 import { AppSidebar } from './components/app-sidebar.tsx'
+import { MobileHeader } from './components/mobile-header.tsx'
 import { ThemeProvider } from './components/theme-provider.tsx'
 import { SidebarProvider } from './components/ui/sidebar.tsx'
 import { Toaster } from './components/ui/sonner.tsx'
@@ -35,14 +36,17 @@ export default function App() {
         <SidebarProvider defaultOpen>
           <AppSidebar />
 
-          <div className="flex flex-col justify-center flex-1 h-screen overflow-hidden">
-            <div
-              className={cn(
-                'flex flex-col max-w-4xl mx-auto relative w-full basis-[100vh] overflow-hidden',
-                'has-[.stick-to-bottom:empty]:overflow-visible has-[.stick-to-bottom:empty]:basis-[0px] transition-[flex-basis] duration-200',
-              )}
-            >
-              {ready && <Chat />}
+          <div className="flex flex-col flex-1 h-dvh overflow-hidden">
+            <MobileHeader />
+            <div className="flex flex-col justify-center flex-1 min-h-0">
+              <div
+                className={cn(
+                  'flex flex-col max-w-4xl mx-auto relative w-full basis-[100dvh] overflow-hidden',
+                  'has-[.stick-to-bottom:empty]:overflow-visible has-[.stick-to-bottom:empty]:basis-[0px] transition-[flex-basis] duration-200',
+                )}
+              >
+                {ready && <Chat />}
+              </div>
             </div>
           </div>
         </SidebarProvider>

--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -388,7 +388,7 @@ const ChatInner = () => {
             autoFocus={true}
           />
           <PromptInputToolbar>
-            <PromptInputTools>
+            <PromptInputTools className="min-w-0 flex-wrap">
               <Tooltip>
                 <TooltipTrigger asChild>
                   <PromptInputButton
@@ -473,7 +473,7 @@ const ChatInner = () => {
                 }}
               />
             </PromptInputTools>
-            <PromptInputSubmit disabled={!input} status={status} />
+            <PromptInputSubmit className="shrink-0 self-end" disabled={!input} status={status} />
           </PromptInputToolbar>
         </PromptInput>
       </div>

--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -388,7 +388,7 @@ const ChatInner = () => {
             autoFocus={true}
           />
           <PromptInputToolbar>
-            <PromptInputTools className="min-w-0 flex-wrap">
+            <PromptInputTools className="min-w-0">
               <Tooltip>
                 <TooltipTrigger asChild>
                   <PromptInputButton
@@ -453,7 +453,7 @@ const ChatInner = () => {
                   }}
                   value={model}
                 >
-                  <PromptInputModelSelectTrigger>
+                  <PromptInputModelSelectTrigger className="min-w-0 [&>span]:truncate">
                     <PromptInputModelSelectValue />
                   </PromptInputModelSelectTrigger>
                   <PromptInputModelSelectContent>
@@ -473,7 +473,7 @@ const ChatInner = () => {
                 }}
               />
             </PromptInputTools>
-            <PromptInputSubmit className="shrink-0 self-end" disabled={!input} status={status} />
+            <PromptInputSubmit className="shrink-0" disabled={!input} status={status} />
           </PromptInputToolbar>
         </PromptInput>
       </div>

--- a/src/components/effort-select.tsx
+++ b/src/components/effort-select.tsx
@@ -26,7 +26,7 @@ const EFFORT_LABELS: Record<ThinkingEffort, string> = {
 
 const EFFORT_OPTIONS: EffortOption[] = [
   ...THINKING_EFFORT_LEVELS.map((level) => ({
-    label: `Effort: ${EFFORT_LABELS[level]}`,
+    label: EFFORT_LABELS[level],
     selectValue: level,
   })),
 ]
@@ -39,12 +39,14 @@ interface EffortSelectProps {
 export const EffortSelect = ({ value, onValueChange }: EffortSelectProps) => {
   return (
     <PromptInputModelSelect value={value} onValueChange={onValueChange}>
-      <PromptInputModelSelectTrigger>
+      <PromptInputModelSelectTrigger className="shrink-0">
         <PromptInputModelSelectValue />
       </PromptInputModelSelectTrigger>
       <PromptInputModelSelectContent>
         {EFFORT_OPTIONS.map((opt) => (
           <PromptInputModelSelectItem key={opt.selectValue} value={opt.selectValue}>
+            {/* The prefix is dropped on narrow screens so the toolbar fits on one row. */}
+            <span className="hidden sm:inline">Effort: </span>
             {opt.label}
           </PromptInputModelSelectItem>
         ))}

--- a/src/components/mobile-header.tsx
+++ b/src/components/mobile-header.tsx
@@ -1,0 +1,15 @@
+import { SidebarTrigger } from '@/components/ui/sidebar'
+
+import logoSvg from '../assets/logo.svg'
+
+export function MobileHeader() {
+  return (
+    <header className="flex shrink-0 items-center gap-2 border-b p-2 md:hidden">
+      <SidebarTrigger />
+      <h1 className="text-l font-medium">
+        <img src={logoSvg} className="inline h-4 mr-2 mb-1" />
+        Pydantic AI
+      </h1>
+    </header>
+  )
+}


### PR DESCRIPTION
On mobile the only `SidebarTrigger` was inside the sidebar itself, which shadcn renders as a closed off-canvas drawer below `md` - so conversation history, new-conversation, and the theme toggle were unreachable on phones. This adds a mobile-only header with a trigger outside the drawer, and swaps `h-screen`/`basis-[100vh]` for `dvh` units so the layout tracks the visual viewport when mobile browsers show/hide the URL bar and keyboard.