### PR TITLE
ci: disable husky hooks during semantic-release commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,5 +41,9 @@ jobs:
 
       - name: Release
         env:
+          # Skip husky hooks: @semantic-release/git commits CHANGELOG.md + package.json,
+          # which would otherwise fire the pre-commit hook (gen:constants needs `uv`, plus
+          # typecheck/test) and fail on the Node-only release runner.
+          HUSKY: 0
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
The 2.0.0 release run (and the earlier Jun-27 run) **failed at publish time**: `@semantic-release/git` commits `CHANGELOG.md` + `package.json`, which fires the `.husky/pre-commit` hook — `gen:constants` (`cd agent && uv run python …`), `typecheck`, `test` — and the Node-only release runner has no `uv`, so the commit fails (`uv: not found`) and semantic-release aborts **before** the npm publish. Net: 2.0.0 was computed correctly but never published (npm/CDN still 1.2.0).

Fix: set `HUSKY: 0` on the Release step. The release commit is `[skip ci]` and only bumps the changelog + version — it doesn't need the pre-commit suite (which already ran on the merged PRs).

**Merging this re-fires `release.yml`**, which recomputes 2.0.0 (the `feat!` breaking commit is still in range since v1.2.0 was never tagged) and this time publishes `@pydantic/ai-chat-ui@2.0.0` to npm → jsdelivr.

Pre-existing pipeline bug — surfaced while cutting 2.0.0 to unblock the pydantic-ai chat-UI integration.