### PR TITLE
feat: add offline single-file build for self-hosting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,11 @@ jobs:
       - name: Run deterministic E2E tests
         run: pnpm run test:e2e
 
+      # Builds the single-file artifact and asserts it renders with every external
+      # request blocked -- the regression guard for the CDN base leaking back in.
+      - name: Run offline artifact E2E test
+        run: pnpm run test:e2e:offline
+
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,11 @@ jobs:
       - name: Build
         run: pnpm run build
 
+      # Ships offline/index.html in the tarball, so it is fetchable from
+      # https://cdn.jsdelivr.net/npm/@pydantic/ai-chat-ui/offline/index.html
+      - name: Build offline artifact
+        run: pnpm run build:offline
+
       - name: Verify npm signatures
         run: npm audit signatures
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
-offline
+/offline
 *.local
 
 # Editor directories and files

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+offline
 *.local
 
 # Editor directories and files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ A React-based chat interface for Pydantic AI that uses Vercel AI SDK and Element
 npm install
 npm run dev              # Start dev server (proxies /api to localhost:8000)
 npm run build            # Build for production (CDN deployment via jsdelivr)
+npm run build:offline    # Build offline/index.html, one self-contained file for air-gapped hosting
 npm run typecheck        # Type check without emitting
 npm run lint             # Run ESLint
 npm run lint-fix         # Fix ESLint issues
@@ -37,16 +38,18 @@ pnpm test:headless       # Vitest unit/integration against the FastAPI test serv
 pnpm test:e2e            # Deterministic Playwright E2E (no API keys needed)
 pnpm test:e2e:llm        # Live-LLM Playwright E2E (requires provider API keys)
 pnpm test:e2e:ui         # Playwright in UI mode for debugging
+pnpm test:e2e:offline    # Build the offline artifact and assert it renders with the network blocked
 pnpm test:server         # Just the FastAPI test server (port 38787), for iterating manually
 ```
 
-Set `E2E_VIDEO=1` to record screen videos with `slowMo`. Set `E2E_TEST_DIR=<path>` to override which directory Playwright walks (defaults to `tests/e2e`; `pnpm test:e2e` narrows it to `tests/e2e/deterministic`).
+Set `E2E_VIDEO=1` to record screen videos with `slowMo`. Set `E2E_TEST_DIR=<path>` to override which directory Playwright walks (defaults to `tests/e2e`; `pnpm test:e2e` narrows it to `tests/e2e/deterministic`). The offline suite ignores `E2E_TEST_DIR` — it runs off its own `playwright.offline.config.ts`, which serves the built artifact with `vite preview` instead of the dev server.
 
 Test infrastructure lives entirely in `tests/`:
 
-- `tests/server/server.py` — deterministic FastAPI server wired to pydantic-ai's `FunctionModel`. Defines the named model registry (`text`, `tool`, `multi-tool`, `error`, `approval`, plus live `anthropic`/`openai`/`google`) that specs select via `sendMessage(page, '<name>', '...')`.
+- `tests/server/server.py` — deterministic FastAPI server wired to pydantic-ai's `FunctionModel`. Defines the named model registry (`text`, `markdown`, `tool`, `multi-tool`, `repeated-tool`, `error`, `approval`, plus live `anthropic`/`openai`/`google`) that specs select via `sendMessage(page, '<name>', '...')`.
 - `tests/chat-client.ts`, `tests/global-setup.ts` — Vitest helpers that spawn an ephemeral test server on an OS-assigned port.
 - `tests/e2e/deterministic/*.spec.ts` — Playwright specs run on every PR against `FunctionModel`-backed fixtures.
+- `tests/e2e/offline/*.spec.ts` — Playwright specs against the built `offline/index.html` with every non-loopback request aborted, so an asset that stops being inlined fails the run instead of being quietly served by the real CDN.
 - `tests/e2e/llm/llm.spec.ts` — live-provider smoke tests, gated on `workflow_dispatch` in CI.
 - `tests/headless/*.test.ts` — Vitest tests exercising the wire protocol directly via `TestChat` (no browser).
 

--- a/package.json
+++ b/package.json
@@ -22,17 +22,20 @@
     "dev:server": "cd agent && uv run uvicorn chatbot.server:app --port 38001",
     "gen:constants": "cd agent && uv run python scripts/gen_constants.py",
     "build": "tsc -b && vite build",
+    "build:offline": "tsc -b && vite build --mode offline",
     "preview": "vite preview",
     "test": "pnpm test:headless && pnpm test:e2e",
     "test:headless": "vitest run --config vitest.config.ts",
     "test:e2e": "E2E_TEST_DIR=tests/e2e/deterministic playwright test",
     "test:e2e:llm": "E2E_TEST_DIR=tests/e2e/llm playwright test",
     "test:e2e:ui": "E2E_TEST_DIR=tests/e2e/deterministic playwright test --ui",
+    "test:e2e:offline": "pnpm run build:offline && playwright test --config playwright.offline.config.ts",
     "test:server": "cd tests/server && uv run uvicorn server:app --host 127.0.0.1 --port 38787",
     "typecheck:test": "tsc --noEmit -p tsconfig.test.json"
   },
   "files": [
-    "dist"
+    "dist",
+    "offline"
   ],
   "dependencies": {
     "@ai-sdk/react": "^4.0.15",
@@ -104,6 +107,7 @@
     "typescript-eslint": "^8.53.1",
     "vite": "^7.3.1",
     "vite-bundle-analyzer": "^1.3.2",
+    "vite-plugin-singlefile": "^2.3.3",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^4.1.6",
     "yaml-lint": "^1.7.0"

--- a/playwright.offline.config.ts
+++ b/playwright.offline.config.ts
@@ -1,0 +1,63 @@
+import { defineConfig, devices } from '@playwright/test'
+
+// Separate config from playwright.config.ts because the offline artifact is served by
+// `vite preview` out of offline/ rather than the dev server, and the spec asserts that
+// nothing at all is fetched from outside the local host.
+
+// Local-dev shim for HTTP firewalls (e.g. Socket Firewall) that set
+// HTTP_PROXY=http://127.0.0.1:<port>. Without bypassing loopback, Playwright's
+// URL probe gets routed through the proxy and returns 405, stalling the
+// webServer wait. Harmless when no proxy is configured.
+const LOOPBACK = ['localhost', '127.0.0.1', '::1']
+const noProxy = (process.env.NO_PROXY ?? '').split(',').filter(Boolean)
+for (const host of LOOPBACK) {
+  if (!noProxy.includes(host)) noProxy.push(host)
+}
+process.env.NO_PROXY = noProxy.join(',')
+process.env.no_proxy = process.env.NO_PROXY
+
+const TEST_SERVER_PORT = 38788
+const TEST_UI_PORT = 54322
+
+export default defineConfig({
+  testDir: 'tests/e2e/offline',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  expect: {
+    timeout: 5_000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  use: {
+    baseURL: `http://127.0.0.1:${TEST_UI_PORT}`,
+    trace: 'retain-on-failure',
+  },
+  webServer: [
+    {
+      command: `cd tests/server && uv run uvicorn server:app --host 127.0.0.1 --port ${TEST_SERVER_PORT}`,
+      url: `http://127.0.0.1:${TEST_SERVER_PORT}/api/configure`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 30_000,
+    },
+    {
+      // Serves the pre-built artifact; run `pnpm run build:offline` first (the
+      // `test:e2e:offline` script does). Building here instead would fold a 30s compound
+      // command into the readiness wait.
+      command:
+        `BACKEND_PORT=${TEST_SERVER_PORT} ` +
+        `pnpm exec vite preview --outDir offline --port ${TEST_UI_PORT} --host 127.0.0.1 --strictPort`,
+      // Probe the proxied API rather than `/`: the readiness fetch would otherwise pull the
+      // whole 15MB artifact, and this also confirms the /api proxy is wired up.
+      url: `http://127.0.0.1:${TEST_UI_PORT}/api/configure`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 30_000,
+    },
+  ],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
       vite-bundle-analyzer:
         specifier: ^1.3.2
         version: 1.3.6
+      vite-plugin-singlefile:
+        specifier: ^2.3.3
+        version: 2.3.3(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@5.8.3)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
@@ -5569,6 +5572,16 @@ packages:
   vite-bundle-analyzer@1.3.6:
     resolution: {integrity: sha512-elFXkF9oGy4CJEeOdP1DSEHRDKWfmaEDfT9/GuF4jmyfmUF6nC//iN+ythqMEVvrtchOEHGKLumZwnu1NjoI0w==}
     hasBin: true
+
+  vite-plugin-singlefile@2.3.3:
+    resolution: {integrity: sha512-XVnGH0QzbOa8fxRSsHdCarVN1BSBXNi7uLMQYlrGRN5apdHkk62XQWRJhVever0lnfuyBkwn+kvVChdm/OoOUg==}
+    engines: {node: '>18.0.0'}
+    peerDependencies:
+      rollup: ^4.59.0
+      vite: ^5.4.21 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
 
   vite-tsconfig-paths@5.1.4:
     resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
@@ -11757,6 +11770,11 @@ snapshots:
       vfile-message: 4.0.3
 
   vite-bundle-analyzer@1.3.6: {}
+
+  vite-plugin-singlefile@2.3.3(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)):
+    dependencies:
+      micromatch: 4.0.8
+      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
 
   vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)):
     dependencies:

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Paradigm: server-driven, no `page.route` mocks
 
-All deterministic tests drive the real FastAPI server at `tests/server/server.py`, which uses pydantic-ai's `FunctionModel` to return predictable streams. The named entries in `models` (`text`, `tool`, `multi-tool`, `error`, `approval`) are the test fixtures — a spec picks one via `sendMessage(page, '<name>', '<message>')`.
+All deterministic tests drive the real FastAPI server at `tests/server/server.py`, which uses pydantic-ai's `FunctionModel` to return predictable streams. The named entries in `models` (`text`, `markdown`, `tool`, `multi-tool`, `repeated-tool`, `error`, `approval`) are the test fixtures — a spec picks one via `sendMessage(page, '<name>', '<message>')`.
 
 When you need new behavior, add a `FunctionModel` to the server's `models` dict and select it from the spec. **Do not** introduce `page.route` mocks — they duplicated the SSE wire format and drifted on the SDK v5→v6 bump, which is why we switched.
 
@@ -28,6 +28,7 @@ When you need new behavior, add a `FunctionModel` to the server's `models` dict 
 
 - `tests/server/` — the FastAPI test server (Python, owned by `uv`)
 - `tests/e2e/deterministic/*.spec.ts` — Playwright specs against `FunctionModel` fixtures (run on every PR)
+- `tests/e2e/offline/*.spec.ts` — Playwright specs against the built `offline/index.html`, run on every PR under `playwright.offline.config.ts` (not `E2E_TEST_DIR`) because they need `vite preview` serving the artifact rather than the dev server
 - `tests/e2e/llm/*.spec.ts` — live-provider Playwright specs (gated on `workflow_dispatch`)
 - `tests/e2e/{conversation,sidebar,tools}.ts` — shared spec helpers
 - `tests/headless/*.test.ts` — Vitest tests that exercise the wire protocol directly via `TestChat` (no browser)

--- a/tests/e2e/offline/offline-artifact.spec.ts
+++ b/tests/e2e/offline/offline-artifact.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test'
+import type { Page } from '@playwright/test'
+import { sendMessage } from '../conversation'
+
+// The bug (pydantic-ai#5318): the CDN build bakes an absolute jsdelivr base into
+// index.html *and* into the runtime chunk loader, so a self-hosted copy silently reaches
+// back out to the CDN. `--mode offline` inlines everything into one file.
+//
+// Blocking every non-loopback request is what gives this spec teeth: if an asset stopped
+// being inlined, the request would be aborted rather than quietly served by the real CDN,
+// so the render fails instead of passing on a machine that happens to be online.
+// A URL predicate rather than a glob so loopback traffic is never intercepted: routing the
+// 15MB document and the streaming /api/chat response through the interception layer stalls
+// the run.
+async function blockExternalRequests(page: Page): Promise<string[]> {
+  const attempted: string[] = []
+  await page.route(
+    ({ hostname }) => hostname !== '127.0.0.1' && hostname !== 'localhost',
+    (route) => {
+      attempted.push(route.request().url())
+      return route.abort()
+    },
+  )
+  return attempted
+}
+
+test.describe('offline artifact', () => {
+  test('renders code blocks and math with no external requests', async ({ page }) => {
+    const attempted = await blockExternalRequests(page)
+
+    await page.goto('/')
+    await sendMessage(page, 'markdown', 'Show me markdown')
+
+    // A fenced code block resolves a shiki language grammar through a dynamic import. In
+    // the CDN build that import is fetched from jsdelivr at runtime; here it must already
+    // be in the bundle, or this text never appears.
+    await expect(page.getByText('def greet():')).toBeVisible()
+
+    // KaTeX rendering the math is what pulls in its stylesheet, whose url() font refs are
+    // the other thing that has to be inlined. `E=mc2` is the typeset output -- unrendered
+    // markdown would still read `$$`.
+    await expect(page.getByText('E=mc2').first()).toBeVisible()
+
+    // The real assertion for the fonts: anything still living on the CDN shows up here.
+    expect(attempted).toEqual([])
+  })
+})

--- a/tests/server/server.py
+++ b/tests/server/server.py
@@ -73,6 +73,15 @@ async def stream_text(
     yield "Hello from the test server!"
 
 
+async def stream_markdown(
+    messages: list[ModelMessage], info: AgentInfo
+) -> AsyncIterator[str]:
+    """Markdown exercising the two lazily-loaded renderers: a fenced code block pulls a
+    shiki language grammar via dynamic import, and math pulls the KaTeX fonts. The offline
+    single-file artifact must render both with no network access."""
+    yield "Fenced code block:\n\n```python\ndef greet():\n    return 'offline'\n```\n\nAnd math:\n\n$$\nE = mc^2\n$$\n"
+
+
 async def stream_tool(
     messages: list[ModelMessage], info: AgentInfo
 ) -> AsyncIterator[str | dict[int, DeltaToolCall]]:
@@ -196,6 +205,7 @@ async def stream_repeated_approval(
 
 models: dict[str, object] = {
     "text": FunctionModel(stream_function=stream_text),
+    "markdown": FunctionModel(stream_function=stream_markdown),
     "tool": FunctionModel(stream_function=stream_tool),
     "multi-tool": FunctionModel(stream_function=stream_multi_tool),
     "repeated-tool": FunctionModel(stream_function=stream_repeated_tool),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,13 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src", "tests", "eslint.config.ts", "vite.config.ts", "playwright.config.ts", "vitest.config.ts"]
+  "include": [
+    "src",
+    "tests",
+    "eslint.config.ts",
+    "vite.config.ts",
+    "playwright.config.ts",
+    "playwright.offline.config.ts",
+    "vitest.config.ts"
+  ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,25 +1,71 @@
+import { readFileSync } from 'node:fs'
+import { extname, resolve } from 'node:path'
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
+import type { Plugin } from 'vite'
 import { defineConfig } from 'vite'
+import { viteSingleFile } from 'vite-plugin-singlefile'
 import tsconfigPaths from 'vite-tsconfig-paths'
 // import { analyzer } from 'vite-bundle-analyzer'
 
 // 8000 is quite common for backend, avoid the clash
 const BACKEND_DEV_SERVER_PORT = process.env.BACKEND_PORT ?? 38001
 
-// https://vite.dev/config/
-export default defineConfig(({ command }) => ({
-  plugins: [react(), tailwindcss(), tsconfigPaths({ root: __dirname })],
-  base: command === 'build' ? 'https://cdn.jsdelivr.net/npm/@pydantic/ai-chat-ui/dist/' : '',
-  build: {
-    assetsDir: 'assets',
+const API_PROXY = {
+  '/api': {
+    target: `http://localhost:${BACKEND_DEV_SERVER_PORT}/`,
+    changeOrigin: true,
   },
-  server: {
-    proxy: {
-      '/api': {
-        target: `http://localhost:${BACKEND_DEV_SERVER_PORT}/`,
-        changeOrigin: true,
-      },
+}
+
+const FAVICON_MIME_TYPES: Record<string, string | undefined> = {
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.ico': 'image/x-icon',
+}
+
+// vite-plugin-singlefile inlines <script> and <link rel="stylesheet">, but favicons are
+// plain public/ files it leaves as relative hrefs. Without this they'd 404 in the
+// single-file artifact, which has no sibling files to resolve against.
+function inlineFavicons(): Plugin {
+  return {
+    name: 'inline-favicons',
+    transformIndexHtml(html) {
+      return html.replace(/href="\.\/([\w-]+\.(?:svg|png|ico))"/g, (link, fileName: string) => {
+        const mimeType = FAVICON_MIME_TYPES[extname(fileName)]
+        if (mimeType === undefined) return link
+        const base64 = readFileSync(resolve(__dirname, 'public', fileName)).toString('base64')
+        return `href="data:${mimeType};base64,${base64}"`
+      })
     },
-  },
-}))
+  }
+}
+
+// https://vite.dev/config/
+export default defineConfig(({ command, mode }) => {
+  // `--mode offline` emits a single self-contained index.html for air-gapped hosting
+  // (pydantic-ai's `to_web(html_source=...)` takes one file). Everything is inlined:
+  // the lazily-imported chunks, which would otherwise be fetched from the CDN base at
+  // runtime, and the KaTeX fonts referenced by url() from its stylesheet.
+  const offline = mode === 'offline'
+
+  return {
+    plugins: [
+      react(),
+      tailwindcss(),
+      tsconfigPaths({ root: __dirname }),
+      ...(offline ? [inlineFavicons(), viteSingleFile()] : []),
+    ],
+    base: offline ? './' : command === 'build' ? 'https://cdn.jsdelivr.net/npm/@pydantic/ai-chat-ui/dist/' : '',
+    build: {
+      assetsDir: 'assets',
+      // The favicons are inlined above, so nothing should be copied next to index.html --
+      // the artifact is meant to be exactly one file.
+      ...(offline ? { outDir: 'offline', copyPublicDir: false } : {}),
+    },
+    server: { proxy: API_PROXY },
+    // The offline E2E spec serves the built artifact with `vite preview`, which needs the
+    // same /api proxy the dev server has.
+    preview: { proxy: API_PROXY },
+  }
+})


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-4-8 on behalf of David. David reviewed and approved the mechanism before implementation; the code has had a light review.

Fixes the offline-hosting path in pydantic/pydantic-ai#5318.

## Root cause

`vite.config.ts` sets `base` to an absolute jsdelivr URL on `build` — right for the hosted case, but it makes a downloaded `index.html` unusable offline. Two layers, the second easy to miss:

1. Entry `index.html` — script, stylesheet and favicon hrefs are all absolute CDN URLs.
2. Baked into the bundle — the entry chunk carries `Mf="https://cdn.jsdelivr.net/.../dist/"`, which Vite's `__vitePreload` uses to fetch the **409 lazy chunks** (shiki grammars, mermaid, cytoscape) at runtime; KaTeX's stylesheet also `url()`s ~1MB of fonts absolutely.

So inlining only the entry assets isn't enough — the page boots, then the first code block or math expression hits the CDN.

## Change

`vite build --mode offline` emits `offline/index.html`, a single ~15.9MB self-contained file: `vite-plugin-singlefile` folds the lazy chunks into the bundle and inlines fonts as data URIs, a small `transformIndexHtml` hook inlines the favicons, and `copyPublicDir: false` keeps it to exactly one file.

The default CDN build is untouched — verified byte-identical (same asset hashes, same 409 assets, same `index.html`).

The artifact ships in the npm tarball, so it's fetchable from `https://cdn.jsdelivr.net/npm/@pydantic/ai-chat-ui/offline/index.html` and can be handed straight to pydantic-ai's `to_web(html_source=...)`, which takes a single file.

## Proof it's really offline

`tests/e2e/offline/offline-artifact.spec.ts` blocks every non-loopback request, then renders a code block (lazy grammar chunk must be inlined) and math (KaTeX must run, and its fonts show up as a blocked request if they aren't inlined). Negative control verified: pointed at the current CDN build, the spec fails — the app can't even mount. Uses a new `markdown` `FunctionModel` fixture, per `tests/CLAUDE.md`'s server-driven convention.

## Maintainer calls

- **Tarball grows 3.70 → 7.48 MiB (+3.77 MiB)**, on every `npm i`. A GitHub Release asset avoids this but jsdelivr can't serve it. Easy to switch if you'd rather not carry it.
- The offline suite has its own `playwright.offline.config.ts` (serves the built artifact via `vite preview`) and runs as a separate CI step.

## Caveat

On macOS these Playwright runs pass every test then never exit — Playwright can't tear down the `uv`/`vite` webServers. Reproduces on `main` with the existing suite, so pre-existing, not from this change; CI's Linux container is unaffected. Flagging so it isn't a surprise.
