### PR TITLE
Add opaque MCP connection selection contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Built with [Vercel AI SDK](https://sdk.vercel.ai/) and designed to work with Pyd
 - Tool call visualization with collapsible input/output
 - Conversation persistence via localStorage
 - Dynamic model and tool selection
+- Server-provided MCP connection selection (browser-to-BFF opaque IDs only)
 - Dark/light theme support
 - Mobile-responsive sidebar
 

--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -17,6 +17,7 @@ import { Source, Sources, SourcesContent, SourcesTrigger } from '@/components/ai
 import { EffortSelect } from '@/components/effort-select'
 import { EditMessageDialog } from '@/components/edit-message-dialog'
 import { HiddenToolsGroup } from '@/components/hidden-tools-group'
+import { McpConnectionsMenu, type McpConnection } from '@/components/mcp-connections-menu'
 import { ToolCallGroup } from '@/components/tool-call-group'
 import { ToolFiltersDialog } from '@/components/tool-filters-dialog'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
@@ -57,6 +58,7 @@ interface BuiltinTool {
 interface RemoteConfig {
   models: ModelConfig[]
   builtinTools: BuiltinTool[]
+  mcpConnections?: McpConnection[]
 }
 
 async function getModels() {
@@ -75,17 +77,25 @@ const ChatInner = () => {
     return stored && stored !== '' ? stored : 'medium'
   })
   const [enabledTools, setEnabledTools] = useState<string[]>([])
+  const [selectedMcpConnectionIds, setSelectedMcpConnectionIds] = useState<string[]>([])
   const modelRef = useRef(model)
   modelRef.current = model
   const effortRef = useRef(effort)
   effortRef.current = effort
   const enabledToolsRef = useRef(enabledTools)
   enabledToolsRef.current = enabledTools
+  const selectedMcpConnectionIdsRef = useRef(selectedMcpConnectionIds)
+  selectedMcpConnectionIdsRef.current = selectedMcpConnectionIds
 
   const [transport] = useState(
     () =>
       new DefaultChatTransport({
-        body: () => ({ model: modelRef.current, builtinTools: enabledToolsRef.current, effort: effortRef.current }),
+        body: () => ({
+          model: modelRef.current,
+          builtinTools: enabledToolsRef.current,
+          effort: effortRef.current,
+          mcpConnections: selectedMcpConnectionIdsRef.current,
+        }),
       }),
   )
   const { messages, sendMessage, status, setMessages, regenerate, error, clearError, addToolApprovalResponse } =
@@ -114,6 +124,8 @@ const ChatInner = () => {
   useEffect(() => {
     if (configQuery.data) {
       setModel(configQuery.data.models[0].id)
+      const validConnectionIds = new Set(configQuery.data.mcpConnections?.map((connection) => connection.id))
+      setSelectedMcpConnectionIds((connectionIds) => connectionIds.filter((id) => validConnectionIds.has(id)))
     }
   }, [configQuery.data])
 
@@ -445,6 +457,13 @@ const ChatInner = () => {
                     ))}
                   </DropdownMenuContent>
                 </DropdownMenu>
+              )}
+              {(configQuery.data?.mcpConnections?.length ?? 0) > 0 && (
+                <McpConnectionsMenu
+                  connections={configQuery.data?.mcpConnections ?? []}
+                  selectedConnectionIds={selectedMcpConnectionIds}
+                  onSelectedConnectionIdsChange={setSelectedMcpConnectionIds}
+                />
               )}
               {configQuery.data && model && (
                 <PromptInputModelSelect

--- a/src/components/mcp-connections-menu.tsx
+++ b/src/components/mcp-connections-menu.tsx
@@ -1,0 +1,77 @@
+import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
+import { Switch } from '@/components/ui/switch'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { PlugZapIcon } from 'lucide-react'
+
+import { PromptInputButton } from './ai-elements/prompt-input'
+
+export interface McpConnection {
+  id: string
+  name: string
+}
+
+interface McpConnectionsMenuProps {
+  connections: McpConnection[]
+  selectedConnectionIds: string[]
+  onSelectedConnectionIdsChange: (connectionIds: string[]) => void
+}
+
+export function McpConnectionsMenu({
+  connections,
+  selectedConnectionIds,
+  onSelectedConnectionIdsChange,
+}: McpConnectionsMenuProps) {
+  const toggleConnection = (connectionId: string) => {
+    onSelectedConnectionIdsChange(
+      selectedConnectionIds.includes(connectionId)
+        ? selectedConnectionIds.filter((id) => id !== connectionId)
+        : [...selectedConnectionIds, connectionId],
+    )
+  }
+
+  return (
+    <DropdownMenu>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <PromptInputButton
+              variant={selectedConnectionIds.length > 0 ? 'default' : 'outline'}
+              aria-label="MCP connections"
+              aria-pressed={selectedConnectionIds.length > 0}
+            >
+              <PlugZapIcon className="size-4" />
+              {selectedConnectionIds.length > 0 && <span>{selectedConnectionIds.length}</span>}
+            </PromptInputButton>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>MCP connections</TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent align="start">
+        {connections.map((connection) => {
+          const selected = selectedConnectionIds.includes(connection.id)
+          return (
+            <div
+              key={connection.id}
+              className="flex items-center justify-between gap-3 px-2 py-1.5 cursor-pointer hover:bg-accent rounded-sm"
+              onClick={() => {
+                toggleConnection(connection.id)
+              }}
+            >
+              <span className="text-sm">{connection.name}</span>
+              <Switch
+                aria-label={`Use ${connection.name}`}
+                checked={selected}
+                onCheckedChange={() => {
+                  toggleConnection(connection.id)
+                }}
+                onClick={(event) => {
+                  event.stopPropagation()
+                }}
+              />
+            </div>
+          )
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/tests/e2e/deterministic/mcp-connections.spec.ts
+++ b/tests/e2e/deterministic/mcp-connections.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test'
+
+import { sendMessage } from '../conversation'
+
+test.describe('MCP connections', () => {
+  test('sends only a selected server-provided connection ID', async ({ page }) => {
+    await page.goto('/')
+
+    await page.getByRole('button', { name: 'MCP connections' }).click()
+    await page.getByText('Test MCP', { exact: true }).click()
+
+    const requestPromise = page.waitForRequest('**/api/chat')
+    await sendMessage(page, 'text', 'use the MCP connection')
+    const request = await requestPromise
+
+    const body: unknown = request.postDataJSON()
+    expect(body).toEqual(expect.objectContaining({ mcpConnections: ['test-mcp'] }))
+    expect(body).not.toHaveProperty('mcpHeaders')
+    expect(body).not.toHaveProperty('mcpAuth')
+
+    await expect(page.getByText('Hello from the test server')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'MCP connections' })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  test('does not retain selected connections after reload', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: 'MCP connections' }).click()
+    await page.getByText('Test MCP', { exact: true }).click()
+
+    await page.reload()
+    await page.getByRole('button', { name: 'MCP connections' }).click()
+
+    await expect(page.getByRole('switch', { name: 'Use Test MCP' })).not.toBeChecked()
+  })
+})

--- a/tests/headless/mcp-connections.test.ts
+++ b/tests/headless/mcp-connections.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { getServerPort } from '../chat-client'
+
+type McpConnections = string | string[]
+
+async function postChat(mcpConnections: McpConnections, extra: Record<string, boolean> = {}) {
+  const port = getServerPort()
+  return fetch(`http://127.0.0.1:${port}/api/chat`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      id: 'mcp-connection-contract',
+      trigger: 'submit-message',
+      messages: [{ id: 'message-1', role: 'user', parts: [{ type: 'text', text: 'hello' }] }],
+      mcpConnections,
+      ...extra,
+    }),
+  })
+}
+
+describe('MCP connection request contract', () => {
+  it('rejects a malformed connection selection', async () => {
+    const response = await postChat('test-mcp')
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({ error: 'mcpConnections must be a list of connection IDs' })
+  })
+
+  it('rejects an unknown connection ID', async () => {
+    const response = await postChat(['unknown-mcp'])
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({ error: "Unknown MCP connection(s): ['unknown-mcp']" })
+  })
+
+  it('ignores unrelated request extras', async () => {
+    const response = await postChat([], { futureSdkOption: true })
+
+    expect(response.ok).toBe(true)
+  })
+})

--- a/tests/server/server.py
+++ b/tests/server/server.py
@@ -220,6 +220,7 @@ models: dict[str, object] = {
 }
 
 SDK_VERSION: Literal[5, 6] = 6
+MCP_CONNECTION_IDS = frozenset({'test-mcp'})
 
 
 async def configure(request: Request) -> Response:
@@ -227,12 +228,22 @@ async def configure(request: Request) -> Response:
         {"id": f"function:function::{name}", "name": name, "builtinTools": []}
         for name in models
     ]
-    return JSONResponse({"models": model_list, "builtinTools": []})
+    return JSONResponse({
+        "models": model_list,
+        "builtinTools": [],
+        "mcpConnections": [{"id": "test-mcp", "name": "Test MCP"}],
+    })
 
 
 async def chat(request: Request) -> Response:
     adapter = await VercelAIAdapter.from_request(request, agent=agent, sdk_version=SDK_VERSION)
     extra = adapter.run_input.__pydantic_extra__ or {}
+    mcp_connections = extra.get('mcpConnections', [])
+    if not isinstance(mcp_connections, list) or not all(isinstance(connection_id, str) for connection_id in mcp_connections):
+        return JSONResponse({"error": "mcpConnections must be a list of connection IDs"}, status_code=400)
+    if unknown_connections := set(mcp_connections).difference(MCP_CONNECTION_IDS):
+        return JSONResponse({"error": f"Unknown MCP connection(s): {sorted(unknown_connections)}"}, status_code=400)
+
     model_id = extra.get("model")
     model_ref = models.get(model_id.split("::")[-1]) if model_id else None
     return await VercelAIAdapter.dispatch_request(


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

## Context

[#41](https://github.com/pydantic/ai-chat-ui/issues/41) asks for per-user authentication to HTTP MCP servers from the web UI. The broader feature should eventually cover OAuth and compatibility credentials without exposing raw MCP credentials, arbitrary headers, or server URLs to the chat request.

MCP `2026-07-28` removes protocol sessions, `initialize`, `Mcp-Session-Id`, and the standalone GET stream. Authentication remains per request: a bearer token is sent on every protected HTTP request. See the [release announcement](https://blog.modelcontextprotocol.io/posts/2026-07-28/), [Streamable HTTP specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http), and [authorization specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization).

Pydantic AI cannot yet exercise that wire revision on `main`. [pydantic-ai#6738](https://github.com/pydantic/pydantic-ai/pull/6738) is the FastMCP 4 / MCP SDK v2 compatibility work. [pydantic-ai#7372](https://github.com/pydantic/pydantic-ai/pull/7372) records the independent main-based transport contracts and strict dependency gates.

## What this PR implements

This PR establishes the safe browser-to-BFF selection contract that does not depend on FastMCP:

- `/api/configure` may advertise non-secret MCP connection summaries (`id` and `name`).
- The chat composer shows a connection selector and sends only selected opaque IDs in `mcpConnections`.
- Selection is request-local and is not retained across reloads.
- The deterministic server validates that the value is a list of strings and rejects IDs absent from its configured allow-list.
- Tests assert that the browser request contains neither `mcpHeaders` nor `mcpAuth`.

All tests in this PR pass. There are no UI xfails because authenticated MCP execution is not blocked only by a dependency: it also requires a production BFF contract and application authentication. An xfail would prematurely encode an unsettled credential API.

## Security boundary

The browser must eventually send an opaque connection ID, not a credential, token, endpoint, or arbitrary header map. The application BFF must authenticate the route, resolve the connection against the authenticated principal and tenant, keep credentials server-side, and construct outbound MCP authorization independently for every request. Pydantic AI's UI guidance makes the host route the authentication boundary and treats client-supplied state as untrusted. See the [UI security model](https://pydantic.dev/docs/ai/integrations/ui/overview/) and [message-history trust guidance](https://pydantic.dev/docs/ai/core-concepts/message-history/).

The global ID set in `tests/server/server.py` is only a deterministic test fixture. It is not a production authorization design and must not be copied as one: membership in a process-wide set would not prevent one authenticated user selecting another user's connection. Production resolution must be principal-scoped and must reject that cross-user case.

Arbitrary user-supplied MCP URLs additionally require SSRF/redirect/egress controls; the current MCP transport does not inherit Pydantic AI's safe download path. MCP documents the relevant [client-side SSRF risks](https://modelcontextprotocol.io/docs/2026-07-28/tutorials/security/security_best_practices).

## Follow-up sequence

1. Land FastMCP 4 / MCP SDK v2 compatibility and replace the strict gates in pydantic-ai#7372 with capture-server wire tests.
2. Define an application-owned authenticated connection store keyed by principal/tenant, canonical MCP resource, authorization-server issuer, scopes, and credential generation.
3. Add BFF routes for connection lifecycle and OAuth. Prefer Client ID Metadata Documents; DCR is deprecated for new implementations in the [2026 authorization specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization).
4. Resolve selected opaque IDs per chat request, create request-scoped authenticated toolsets, and keep private caches isolated by authorization context according to the [caching specification](https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/caching).
5. Add an authenticated E2E test with two principals. Assert each remote server receives only its principal's credential on every selected MCP POST, receives no traffic for unselected connections, and receives no `Mcp-Session-Id`.
6. Add connection lifecycle UX: disconnected, authenticating, connected, refresh/reconnect, and disconnect/revoke.

MRTR, `subscriptions/listen`, private/public cache policy, OAuth storage, Basic/API-key/custom-header compatibility, and endpoint SSRF policy are deliberately deferred until their backend owners and public contracts exist.

## Verification

- TypeScript typecheck: pass
- Focused lint and formatting: pass
- Build: pass
- Headless suite: pass
- Focused MCP Playwright suite: pass

No dependency versions are changed in this PR.
