### PR TITLE
refactor: validate runtime boundaries with Zod

### DIFF
--- a/src/components/run-code-input.tsx
+++ b/src/components/run-code-input.tsx
@@ -1,6 +1,7 @@
 import { CodeBlock, CodeBlockCopyButton } from '@/components/ai-elements/code-block'
 import { Badge } from '@/components/ui/badge'
 import type { ToolPart } from '@/components/ai-elements/tool'
+import { parseRunCodeInput } from '@/lib/run-code-payload'
 import { memo } from 'react'
 
 // Memoize to avoid re-running highlighters on unchanged code.
@@ -10,15 +11,8 @@ interface RunCodeInputProps {
   input: ToolPart['input']
 }
 
-interface RunCodeFields {
-  code?: unknown
-  restart?: unknown
-}
-
 export function RunCodeInput({ input }: RunCodeInputProps) {
-  const fields = (input ?? {}) as RunCodeFields
-  const code = typeof fields.code === 'string' ? fields.code : ''
-  const restart = fields.restart === true
+  const { code, restart } = parseRunCodeInput(input)
 
   return (
     <div className="space-y-2 overflow-hidden p-4">

--- a/src/components/run-code-output.tsx
+++ b/src/components/run-code-output.tsx
@@ -1,17 +1,11 @@
 import { ToolOutputCode } from '@/components/tool-output-code'
-import type { ToolPart } from '@/components/ai-elements/tool'
+import { type RunCodeResult } from '@/lib/run-code-payload'
 
-export interface RunCodeResult {
-  output?: unknown
-  result?: unknown
-}
+export { isRunCodeOutput } from '@/lib/run-code-payload'
+export type { RunCodeResult } from '@/lib/run-code-payload'
 
 interface RunCodeOutputProps {
   output: RunCodeResult
-}
-
-export function isRunCodeOutput(output: ToolPart['output']): output is RunCodeResult {
-  return typeof output === 'object' && output !== null && ('output' in output || 'result' in output)
 }
 
 export function RunCodeOutput({ output }: RunCodeOutputProps) {

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react'
 import { createContext, useContext, useEffect, useState } from 'react'
+import { z } from 'zod'
 
-type Theme = 'dark' | 'light' | 'system'
+const themeSchema = z.enum(['dark', 'light', 'system'])
+type Theme = z.infer<typeof themeSchema>
 
 interface ThemeProviderProps {
   children: React.ReactNode
@@ -21,14 +23,19 @@ const initialState: ThemeProviderState = {
 
 const ThemeProviderContext = createContext<ThemeProviderState>(initialState)
 
+export function resolveStoredTheme(stored: string | null, defaultTheme: Theme): Theme {
+  const result = themeSchema.safeParse(stored)
+  return result.success ? result.data : defaultTheme
+}
+
 export function ThemeProvider({
   children,
   defaultTheme = 'system',
   storageKey = 'vite-ui-theme',
   ...props
 }: ThemeProviderProps) {
-  const [theme, setTheme] = useState<Theme>(
-    () => (window.localStorage.getItem(storageKey) as Theme | undefined) ?? defaultTheme,
+  const [theme, setTheme] = useState<Theme>(() =>
+    resolveStoredTheme(window.localStorage.getItem(storageKey), defaultTheme),
   )
 
   useEffect(() => {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,4 +1,5 @@
-import { isRecord } from '@/lib/is-record'
+import { z } from 'zod'
+
 import type { BuiltinTool, ModelConfig } from '@/types'
 
 export interface StartupConfig {
@@ -32,22 +33,25 @@ function defaultBasePath(viteBase: string): string {
   return url.origin === PATH_ORIGIN ? normalizeDirectoryPath(url.pathname, 'Vite base') : '/'
 }
 
-function configuredPath(config: unknown, key: keyof StartupConfig): string | undefined {
-  if (config === undefined) return undefined
-  if (!isRecord(config)) throw new TypeError('PYDANTIC_AI_CHAT_CONFIG must be an object')
-  const value = config[key]
-  if (value !== undefined && typeof value !== 'string') {
-    throw new TypeError(`PYDANTIC_AI_CHAT_CONFIG.${key} must be a string`)
-  }
-  return value
-}
+const startupConfigSchema = z
+  .object(
+    {
+      basePath: z.string({ error: 'PYDANTIC_AI_CHAT_CONFIG.basePath must be a string' }).optional(),
+      apiPath: z.string({ error: 'PYDANTIC_AI_CHAT_CONFIG.apiPath must be a string' }).optional(),
+    },
+    { error: 'PYDANTIC_AI_CHAT_CONFIG must be an object' },
+  )
+  .optional()
 
 export function resolveStartupConfig(
   config: unknown = typeof window === 'undefined' ? undefined : window.PYDANTIC_AI_CHAT_CONFIG,
   viteBase: string = import.meta.env.BASE_URL,
 ): ResolvedStartupConfig {
-  const basePath = configuredPath(config, 'basePath')
-  const apiPath = configuredPath(config, 'apiPath')
+  const parsedConfig = startupConfigSchema.safeParse(config)
+  if (!parsedConfig.success) {
+    throw new TypeError(parsedConfig.error.issues[0].message)
+  }
+  const { basePath, apiPath } = parsedConfig.data ?? {}
   return Object.freeze({
     basePath: basePath === undefined ? defaultBasePath(viteBase) : normalizeDirectoryPath(basePath, 'basePath'),
     apiPath: apiPath === undefined ? '/api/' : normalizeDirectoryPath(apiPath, 'apiPath'),
@@ -56,37 +60,23 @@ export function resolveStartupConfig(
 
 export const startupConfig = resolveStartupConfig()
 
-function isModelConfig(value: unknown): value is ModelConfig {
-  if (!isRecord(value)) return false
-  return (
-    typeof value.id === 'string' &&
-    typeof value.name === 'string' &&
-    Array.isArray(value.builtinTools) &&
-    value.builtinTools.every((tool) => typeof tool === 'string')
-  )
-}
+const remoteConfigSchema = z.looseObject({
+  models: z.array(
+    z.looseObject({
+      id: z.string(),
+      name: z.string(),
+      builtinTools: z.array(z.string()),
+    }),
+  ),
+  builtinTools: z.array(z.looseObject({ id: z.string(), name: z.string() })),
+})
 
-function isBuiltinTool(value: unknown): value is BuiltinTool {
-  return isRecord(value) && typeof value.id === 'string' && typeof value.name === 'string'
-}
-
-/**
- * The elements are checked, not just the arrays.
- *
- * A backend that answers with the right keys and the wrong contents used to pass
- * here and fail later in render — a model without `name` reaches the select as a
- * blank option that cannot be told apart from its neighbours, and one without
- * `id` sends a request the server rejects. Rejecting the response instead puts
- * the retry banner in front of it.
- */
-function isRemoteConfig(value: unknown): value is RemoteConfig {
-  if (!isRecord(value)) return false
-  return (
-    Array.isArray(value.models) &&
-    value.models.every(isModelConfig) &&
-    Array.isArray(value.builtinTools) &&
-    value.builtinTools.every(isBuiltinTool)
-  )
+export function parseRemoteConfig(value: unknown): RemoteConfig {
+  const parsedConfig = remoteConfigSchema.safeParse(value)
+  if (!parsedConfig.success) {
+    throw new Error('Configuration response did not contain models and builtin tools')
+  }
+  return parsedConfig.data
 }
 
 /**
@@ -105,8 +95,5 @@ export async function fetchConfig(): Promise<RemoteConfig> {
     throw new Error(`Configuration request failed with ${String(res.status)}`)
   }
   const body: unknown = await res.json()
-  if (!isRemoteConfig(body)) {
-    throw new Error('Configuration response did not contain models and builtin tools')
-  }
-  return body
+  return parseRemoteConfig(body)
 }

--- a/src/lib/run-code-payload.ts
+++ b/src/lib/run-code-payload.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod'
+
+const runCodeInputSchema = z
+  .object({
+    code: z.unknown().transform((value) => (typeof value === 'string' ? value : '')),
+    restart: z.unknown().transform((value) => value === true),
+  })
+  .catch({ code: '', restart: false })
+
+const runCodeOutputSchema = z
+  .looseObject({
+    output: z.unknown().optional(),
+    result: z.unknown().optional(),
+  })
+  .refine((value) => Object.hasOwn(value, 'output') || Object.hasOwn(value, 'result'))
+
+export type RunCodeResult = z.infer<typeof runCodeOutputSchema>
+
+export function parseRunCodeInput(input: unknown) {
+  return runCodeInputSchema.parse(input)
+}
+
+export function isRunCodeOutput(output: unknown): output is RunCodeResult {
+  return runCodeOutputSchema.safeParse(output).success
+}

--- a/src/lib/tool-filters.ts
+++ b/src/lib/tool-filters.ts
@@ -1,4 +1,7 @@
+import { z } from 'zod'
+
 const STORAGE_KEY = 'toolFilters'
+const filtersSchema = z.array(z.string())
 
 /**
  * The minimal shape needed to identify a tool part and read its name. A real
@@ -55,10 +58,8 @@ export function loadFilters(defaults: string[]): string[] {
     const raw = localStorage.getItem(STORAGE_KEY)
     if (raw === null) return defaults
     const parsed: unknown = JSON.parse(raw)
-    if (Array.isArray(parsed) && parsed.every((entry) => typeof entry === 'string')) {
-      return parsed
-    }
-    return defaults
+    const result = filtersSchema.safeParse(parsed)
+    return result.success ? result.data : defaults
   } catch {
     return defaults
   }

--- a/tests/chat-client.ts
+++ b/tests/chat-client.ts
@@ -1,5 +1,7 @@
 import { AbstractChat, DefaultChatTransport, type ChatState, type ChatStatus, type UIMessage } from 'ai'
 
+import { parseRemoteConfig, type RemoteConfig } from '../src/lib/config'
+
 class SimpleChatState implements ChatState<UIMessage> {
   status: ChatStatus = 'ready'
   error: Error | undefined = undefined
@@ -38,26 +40,15 @@ export function getServerPort(): number {
   return Number(port)
 }
 
-interface ModelConfig {
-  id: string
-  name: string
-  builtinTools: string[]
-}
+let cachedConfig: RemoteConfig | undefined
 
-interface ServerConfig {
-  models: ModelConfig[]
-  builtinTools: { name: string; id: string }[]
-}
-
-let cachedConfig: ServerConfig | undefined
-
-async function fetchConfig(port: number): Promise<ServerConfig> {
+async function fetchConfig(port: number): Promise<RemoteConfig> {
   if (cachedConfig) return cachedConfig
   const res = await fetch(`http://127.0.0.1:${port}/api/configure`)
   if (!res.ok) {
     throw new Error(`/api/configure returned ${res.status}`)
   }
-  cachedConfig = (await res.json()) as ServerConfig
+  cachedConfig = parseRemoteConfig(await res.json())
   return cachedConfig
 }
 

--- a/tests/headless/config.test.ts
+++ b/tests/headless/config.test.ts
@@ -15,8 +15,12 @@ afterEach(() => {
 })
 
 describe('fetchConfig', () => {
-  it('returns the configuration', async () => {
-    const config = { models: [{ id: 'a', name: 'a', builtinTools: [] }], builtinTools: [] }
+  it('returns the configuration with unknown fields intact', async () => {
+    const config = {
+      models: [{ id: 'a', name: 'a', builtinTools: [], provider: 'test-provider' }],
+      builtinTools: [{ id: 'web_search', name: 'Web search', category: 'search' }],
+      defaultModel: 'a',
+    }
     respond(config)
 
     await expect(fetchConfig()).resolves.toEqual(config)
@@ -36,6 +40,21 @@ describe('fetchConfig', () => {
     respond({ detail: 'something else entirely' })
 
     await expect(fetchConfig()).rejects.toThrow(/models and builtin tools/)
+  })
+
+  it('keeps JSON parse errors intact', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.reject(new SyntaxError('Unexpected token <')),
+        }),
+      ),
+    )
+
+    await expect(fetchConfig()).rejects.toThrow(SyntaxError)
   })
 
   it('rejects arrays of the wrong shape', async () => {
@@ -86,7 +105,10 @@ describe('startup configuration', () => {
   })
 
   it('rejects malformed startup configuration', () => {
-    expect(() => resolveStartupConfig('demo', '/')).toThrow(/must be an object/)
-    expect(() => resolveStartupConfig({ apiPath: 7 }, '/')).toThrow(/apiPath must be a string/)
+    expect(() => resolveStartupConfig('demo', '/')).toThrow(new TypeError('PYDANTIC_AI_CHAT_CONFIG must be an object'))
+    expect(() => resolveStartupConfig([], '/')).toThrow(new TypeError('PYDANTIC_AI_CHAT_CONFIG must be an object'))
+    expect(() => resolveStartupConfig({ apiPath: 7 }, '/')).toThrow(
+      new TypeError('PYDANTIC_AI_CHAT_CONFIG.apiPath must be a string'),
+    )
   })
 })

--- a/tests/headless/run-code-payload.test.ts
+++ b/tests/headless/run-code-payload.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+
+import { isRunCodeOutput, parseRunCodeInput } from '../../src/lib/run-code-payload'
+
+describe('run code payloads', () => {
+  it('falls back independently for malformed input fields', () => {
+    expect(parseRunCodeInput({ code: 42, restart: true })).toEqual({ code: '', restart: true })
+    expect(parseRunCodeInput({ code: 'print(1)', restart: 'yes' })).toEqual({ code: 'print(1)', restart: false })
+  })
+
+  it('falls back to an empty input for a malformed payload', () => {
+    expect(parseRunCodeInput(null)).toEqual({ code: '', restart: false })
+  })
+
+  it('recognizes output and result payloads with arbitrary values and extra keys', () => {
+    expect(isRunCodeOutput({ output: 'stdout', extra: true })).toBe(true)
+    expect(isRunCodeOutput({ output: 42 })).toBe(true)
+    expect(isRunCodeOutput({ result: null, metadata: { elapsed: 1 } })).toBe(true)
+  })
+
+  it('leaves non-run-code outputs for the generic fallback', () => {
+    expect(isRunCodeOutput(null)).toBe(false)
+    expect(isRunCodeOutput([])).toBe(false)
+    expect(isRunCodeOutput({})).toBe(false)
+    expect(isRunCodeOutput({ extra: true })).toBe(false)
+  })
+})

--- a/tests/headless/theme-provider.test.ts
+++ b/tests/headless/theme-provider.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveStoredTheme } from '../../src/components/theme-provider'
+
+describe('resolveStoredTheme', () => {
+  it('keeps a valid stored theme', () => {
+    expect(resolveStoredTheme('dark', 'system')).toBe('dark')
+  })
+
+  it('falls back for invalid stored themes', () => {
+    expect(resolveStoredTheme('midnight', 'light')).toBe('light')
+    expect(resolveStoredTheme('', 'dark')).toBe('dark')
+    expect(resolveStoredTheme(null, 'system')).toBe('system')
+  })
+})

--- a/tests/headless/tool-filters.test.ts
+++ b/tests/headless/tool-filters.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from 'vitest'
-import { filterMatches, isToolFiltered, toolNameOfPart } from '../../src/lib/tool-filters'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { filterMatches, isToolFiltered, loadFilters, toolNameOfPart } from '../../src/lib/tool-filters'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 describe('filterMatches', () => {
   it('matches exact names', () => {
@@ -75,5 +79,25 @@ describe('toolNameOfPart', () => {
   it('returns null for a non-tool part', () => {
     expect(toolNameOfPart({ type: 'text' })).toBe(null)
     expect(toolNameOfPart({ type: 'reasoning' })).toBe(null)
+  })
+})
+
+describe('loadFilters', () => {
+  const defaults = ['set_*']
+
+  it('falls back to defaults for malformed JSON or values outside the string-array schema', () => {
+    vi.stubGlobal('localStorage', { getItem: () => '{' })
+    expect(loadFilters(defaults)).toBe(defaults)
+
+    vi.stubGlobal('localStorage', { getItem: () => JSON.stringify(['set_*', 3]) })
+    expect(loadFilters(defaults)).toBe(defaults)
+  })
+
+  it('retains valid stored arrays, including an empty one', () => {
+    vi.stubGlobal('localStorage', { getItem: () => JSON.stringify(['read_*']) })
+    expect(loadFilters(defaults)).toEqual(['read_*'])
+
+    vi.stubGlobal('localStorage', { getItem: () => '[]' })
+    expect(loadFilters(defaults)).toEqual([])
   })
 })


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

## Summary

- replace manual runtime guards and casts with Zod schemas at configuration, persisted-preference, and `run_code` payload boundaries
- reuse the production configuration parser in the test client
- preserve permissive behavior where it is intentional, including unknown remote configuration fields and arbitrary `run_code` results

## Behavior

- malformed startup configuration arrays are now rejected as non-objects
- invalid stored theme values fall back to the configured default
- malformed tool filters still fall back to defaults, while valid empty arrays remain valid
- invalid `run_code` input fields fall back independently, without discarding valid sibling fields

## Validation

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run typecheck:test`
- `pnpm run test:headless`
- `pnpm run test:e2e`
- `pnpm run build`
- `pnpm run test:e2e:offline`

The full change adds 537 bytes gzip to the normal entry artifact and 629 bytes gzip to the offline artifact. Zod was already a production dependency and present in both bundles.

Persisted conversations and messages are deliberately out of scope: validating them requires an explicit recovery and forward-compatibility policy for malformed local data. The tolerant usage projection and generated effort-level membership check also remain manual because schemas would not make those transformations clearer.
